### PR TITLE
Implement a locality aware scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For a description of our design decisions, see
 
 - [Reference Counting](doc/reference-counting.md)
 - [Aliasing](doc/aliasing.md)
+- [Scheduler](doc/scheduler.md)
 
 ## Setup
 

--- a/doc/scheduler.md
+++ b/doc/scheduler.md
@@ -1,0 +1,25 @@
+# Scheduler
+
+The scheduling strategies currently implemented in Photon are fairly basic and
+all use a central scheduler.
+
+* The naive scheduler assigns tasks to workers just taking into account
+dependencies between tasks (no other information like data locality). It is
+supposed to be an example for how to write a scheduler. We do not recommend
+its use and it only works well for single node setups. Tasks are assigned in the
+following way: For each idle worker, we iterate over the tasks in the task
+queue. The first task that has all its requirements satisfied will be scheduled
+on the worker.
+
+* The locality aware scheduler is more suited for multi node setups, but still
+inappropriate for very large clusters. This is because the computational
+overhead for each scheduling decision is O(mn) where m is the number of idle
+workers and n is the number of tasks in the task queue. For each idle worker,
+all tasks in the task queue are considered and the one that requires the
+smallest number of objects to be shipped will be executed.
+
+We expect to implement more refined scheduling strategies in the future,
+including more computationally efficient location aware scheduling,
+scheduling that takes into account sizes of the shipped objects, and strategies
+that do not require a central scheduler (which is a bottleneck for large
+clusters).

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -41,8 +41,15 @@ struct ObjStoreHandle {
   std::string address;
 };
 
+enum SchedulingAlgorithmType {
+  SCHEDULING_ALGORITHM_NAIVE = 0,
+  SCHEDULING_ALGORITHM_LOCALITY_AWARE = 1
+};
+
 class SchedulerService : public Scheduler::Service {
 public:
+  SchedulerService(SchedulingAlgorithmType scheduling_algorithm);
+
   Status RemoteCall(ServerContext* context, const RemoteCallRequest* request, RemoteCallReply* reply) override;
   Status PushObj(ServerContext* context, const PushObjRequest* request, PushObjReply* reply) override;
   Status RequestObj(ServerContext* context, const RequestObjRequest* request, AckReply* reply) override;
@@ -86,7 +93,10 @@ private:
   bool is_canonical(ObjRef objref);
 
   void perform_pulls();
-  void schedule_tasks();
+  // schedule tasks using the naive algorithm
+  void schedule_tasks_naively();
+  // schedule tasks using a scheduling algorithm that takes into account data locality
+  void schedule_tasks_location_aware();
   void perform_notify_aliases();
 
   // checks if aliasing for objref has been completed
@@ -149,6 +159,8 @@ private:
   // contained_objrefs_[objref] is a vector of all of the objrefs contained inside the object referred to by objref
   std::vector<std::vector<ObjRef> > contained_objrefs_;
   std::mutex contained_objrefs_lock_;
+  // the scheduling algorithm that will be used
+  SchedulingAlgorithmType scheduling_algorithm_;
 };
 
 #endif


### PR DESCRIPTION
This pull request implements a scheduler which tries to place tasks on nodes that already have the required objects. This makes it possible to scale up examples like dense matrix-matrix multiply to multiple nodes.
