### PR TITLE
Preparation to deallocate objects properly from object stores

### DIFF
--- a/include/ray/ray.h
+++ b/include/ray/ray.h
@@ -10,6 +10,7 @@ typedef size_t ObjRef;
 typedef size_t WorkerId;
 typedef size_t ObjStoreId;
 typedef size_t OperationId;
+typedef size_t SegmentId; // index into a memory segment table
 
 class FnInfo {
   size_t num_return_vals_;
@@ -45,6 +46,7 @@ public:
 struct slice {
   uint8_t* data;
   size_t len;
+  SegmentId segmentid;
 };
 
 #endif

--- a/lib/python/ray/serialization.py
+++ b/lib/python/ray/serialization.py
@@ -1,6 +1,33 @@
 import importlib
+import numpy as np
 
 import ray
+
+# The following definitions are required because Python doesn't allow custom
+# attributes for primitive types. We need custom attributes for (a) implementing
+# destructors that close the shared memory segment that the object resides in
+# and (b) fixing https://github.com/amplab/ray/issues/72.
+
+class Int(int):
+  pass
+
+class Float(float):
+  pass
+
+class List(list):
+  pass
+
+class Dict(dict):
+  pass
+
+class Tuple(tuple):
+  pass
+
+class Str(str):
+  pass
+
+class NDArray(np.ndarray):
+  pass
 
 def to_primitive(obj):
   if hasattr(obj, "serialize"):

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -11,6 +11,15 @@ import ray
 from ray.config import LOG_DIRECTORY, LOG_TIMESTAMP
 import serialization
 
+class RayDealloc(object):
+  def __init__(self, handle, segmentid):
+    self.handle = handle
+    self.segmentid = segmentid
+
+  def __del__(self):
+    # TODO(pcm): This will be used to free the segment
+    pass
+
 class Worker(object):
   """The methods in this class are considered unexposed to the user. The functions outside of this class are considered exposed."""
 
@@ -34,10 +43,33 @@ class Worker(object):
     WARNING: get_object can only be called on a canonical objref.
     """
     if ray.lib.is_arrow(self.handle, objref):
-      return ray.lib.get_arrow(self.handle, objref)
+      result, segmentid = ray.lib.get_arrow(self.handle, objref)
     else:
-      object_capsule = ray.lib.get_object(self.handle, objref)
-      return serialization.deserialize(self.handle, object_capsule)
+      object_capsule, segmentid = ray.lib.get_object(self.handle, objref)
+      result = serialization.deserialize(self.handle, object_capsule)
+    if isinstance(result, int):
+      result = serialization.Int(result)
+    elif isinstance(result, float):
+      result = serialization.Float(result)
+    elif isinstance(result, bool):
+      return result # can't subclass bool, and don't need to because there is a global True/False
+      # TODO(pcm): close the associated memory segment; if we don't, this leaks memory (but very little, so it is ok for now)
+    elif isinstance(result, list):
+      result = serialization.List(result)
+    elif isinstance(result, dict):
+      result = serialization.Dict(result)
+    elif isinstance(result, tuple):
+      result = serialization.Tuple(result)
+    elif isinstance(result, str):
+      result = serialization.Str(result)
+    elif isinstance(result, np.ndarray):
+      result = result.view(serialization.NDArray)
+    elif result == None:
+      return None # can't subclass None and don't need to because there is a global None
+      # TODO(pcm): close the associated memory segment; if we don't, this leaks memory (but very little, so it is ok for now)
+    # TODO(pcm): Here, we can add the object reference to fix https://github.com/amplab/ray/issues/72
+    result.ray_deallocator = RayDealloc(self.handle, segmentid)
+    return result
 
   def alias_objrefs(self, alias_objref, target_objref):
     """Make `alias_objref` refer to the same object that `target_objref` refers to."""

--- a/src/worker.h
+++ b/src/worker.h
@@ -57,7 +57,7 @@ class Worker {
   // stores an arrow object to the local object store
   PyObject* put_arrow(ObjRef objref, PyObject* array);
   // gets an arrow object from the local object store
-  PyObject* get_arrow(ObjRef objref);
+  PyObject* get_arrow(ObjRef objref, SegmentId& segmentid);
   // determine if the object stored in objref is an arrow object // TODO(pcm): more general mechanism for this?
   bool is_arrow(ObjRef objref);
   // make `alias_objref` refer to the same object that `target_objref` refers to


### PR DESCRIPTION
This PR prepares two changes:

- Tracking Python objects and close shared memory segments after they are not referenced any more in the worker
- fixing https://github.com/amplab/ray/issues/72