### PR TITLE
use correct verison of Python on Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,4 +113,11 @@ target_link_libraries(scheduler boost_system boost_filesystem)
 add_library(raylib SHARED src/raylib.cc src/worker.cc src/ipc.cc src/utils.cc ${GENERATED_PROTOBUF_FILES})
 target_link_libraries(raylib ${ARROW_LIB} pynumbuf boost_system boost_filesystem)
 
+get_filename_component(PYTHON_SHARED_LIBRARY ${PYTHON_LIBRARIES} NAME)
+if(APPLE)
+  add_custom_command(TARGET raylib
+      POST_BUILD COMMAND
+      ${CMAKE_INSTALL_NAME_TOOL} -change ${PYTHON_SHARED_LIBRARY} ${PYTHON_LIBRARIES} libraylib.so)
+endif(APPLE)
+
 install(TARGETS objstore scheduler raylib DESTINATION ${CMAKE_SOURCE_DIR}/lib/python/ray)


### PR DESCRIPTION
On Mac OS X, the libraylib.so binary is linked against Python using a relative path.
```
$ cd build
$ otool -L libraylib.so
libraylib.so:
	/Users/rkn/Workspace/ray/build/libraylib.so (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/usr/local/opt/boost/lib/libboost_system.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_filesystem.dylib (compatibility version 0.0.0, current version 0.0.0)
	libpython2.7.dylib (compatibility version 2.7.0, current version 2.7.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
```
Note that Python shows up as `libpython2.7.dylib`. I have Anaconda on my machine, but at runtime, this uses the system's Python, which gives the error below.
```
$ cd build
$ python
Python 2.7.11 |Anaconda 4.0.0 (x86_64)| (default, Dec  6 2015, 18:57:58) 
>>> import libraylib
Fatal Python error: PyThreadState_Get: no current thread
Abort trap: 6
```
We want to link `libraylib.so` with Python using an absolute path. This could be done manually via
```
install_name_tool -change libpython2.7.dylib /Users/rkn/anaconda/lib/libpython2.7.dylib libraylib.so
```
We do exactly this with cmake. So after this commit, we have
```
$ cd build
$ otool -L libraylib.so
libraylib.so:
	/Users/rkn/Workspace/ray/build/libraylib.so (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/usr/local/opt/boost/lib/libboost_system.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_filesystem.dylib (compatibility version 0.0.0, current version 0.0.0)
	/Users/rkn/anaconda/lib/libpython2.7.dylib (compatibility version 2.7.0, current version 2.7.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.1.0)
```
In particular, Python is now `/Users/rkn/anaconda/lib/libpython2.7.dylib`.