### PR TITLE
fix bug for functions with no return values and one return value

### DIFF
--- a/scripts/example_functions.py
+++ b/scripts/example_functions.py
@@ -23,3 +23,7 @@ def dot(a, b):
 @ray.remote([], [])
 def throw_exception():
   raise Exception("This function intentionally failed.")
+
+@ray.remote([], [])
+def no_op():
+  pass

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -87,6 +87,7 @@ def throw_exception_fct3(x):
   raise Exception("Test function 3 intentionally failed.")
 
 # test Python mode
+
 @ray.remote([], [np.ndarray])
 def python_mode_f():
   return np.array([0, 0])
@@ -95,3 +96,23 @@ def python_mode_f():
 def python_mode_g(x):
   x[0] = 1
   return x
+
+# test no return values
+
+@ray.remote([], [])
+def no_op():
+  pass
+
+@ray.remote([], [])
+def no_op_fail():
+  return 0
+
+# test wrong return types
+
+@ray.remote([], [int])
+def test_return1():
+  return 0.0
+
+@ray.remote([], [int, float])
+def test_return2():
+  return 2.0, 3.0


### PR DESCRIPTION
You can try this by starting `python scripts/shell.py` and running
```python
>>> example_functions.no_op()
```
You can check that it succeeded with
```python
>>> ray.task_info()
```
Before this PR, the above would have failed.

Also, because of this commit, if a function with no return values in the `@ray.remote` decorator attempts to return a value, then there will be an error.

This commit also does type checking for remote functions with a single return value (this wasn't being done before).