### PR TITLE
don't destruct worker before all object refs go out of scope

### DIFF
--- a/lib/python/ray/services.py
+++ b/lib/python/ray/services.py
@@ -39,6 +39,13 @@ def new_objstore_port():
   return 20000 + objstore_port_counter
 
 def cleanup():
+  global drivers
+  for driver in drivers:
+    ray.disconnect(driver)
+  if len(drivers) == 0:
+    ray.disconnect()
+  drivers = []
+
   global all_processes
   for p, address in all_processes:
     if p.poll() is not None: # process has already terminated
@@ -58,13 +65,6 @@ def cleanup():
       continue
     print "Termination attempt failed, giving up."
   all_processes = []
-
-  global drivers
-  for driver in drivers:
-    ray.disconnect(driver)
-  if len(drivers) == 0:
-    ray.disconnect()
-  drivers = []
 
 # atexit.register(cleanup)
 


### PR DESCRIPTION
This may address the segfault discussed in #170.

The issue was the following.

1. An object reference would be created.
2. We would call `services.cleanup()` killing the scheduler, object store, and workers, and disconnecting the driver(s).
3. The program would finish causing the object reference and the worker capsule to go out of scope (these could go out of scope in either order).
4. If the worker capsule went out of scope, the worker capsule destructor (`WorkerCapsule_Destructor` in `raylib.cc`) would destroy the worker object.
5. Then the object reference would go out of scope and try to call `self->worker->decrement_reference_count(...)` (note that `PyObjRef` has a pointer to the `Worker` object precisely so it can do this call). However, the worker object has already been deallocated and so this can cause a segfault.

This PR replaces the `PyObjRef` worker field with a worker capsule (which is a Python object). We then increment a Python reference count to the worker capsule in `PyObjRef_init` and decrement the Python reference count in `PyObjRef_dealloc` to ensure that the worker capsule does not go out of scope until all of the object references have already gone out of scope.