### PR TITLE
fix bug, empty function should return nothing

### DIFF
--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -26,7 +26,7 @@ def test_alias_h():
 
 @ray.remote([], [])
 def empty_function():
-  return ()
+  pass
 
 @ray.remote([], [int])
 def trivial_function():


### PR DESCRIPTION
Before this fix, `python test/microbenchmarks.py` fails with the error message
```
    Error: Task failed
      Function Name: test_functions.empty_function
      Task ID: 175
      Error Message: 
          Traceback (most recent call last):
            File "/Users/rkn/Workspace/ray/lib/python/ray/worker.py", line 382, in check_return_values
              raise Exception("The @remote decorator for function {} has 0 return values, but {} returned more than 0 values.".format(function.__name__, function.__name__))
          Exception: The @remote decorator for function test_functions.empty_function has 0 return values, but test_functions.empty_function returned more than 0 values.
```