### PR TITLE
pip install ipython in user mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ typing
 funcsigs
 subprocess32
 protobuf==3.0.0-alpha-2
-IPython
 boto3
 botocore
 Pillow

--- a/setup.sh
+++ b/setup.sh
@@ -31,11 +31,13 @@ fi
 if [[ $platform == "linux" ]]; then
   sudo apt-get update
   sudo apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip libjpeg8-dev graphviz
+  sudo pip install ipython
   sudo pip install -r requirements.txt
 elif [[ $platform == "macosx" ]]; then
   brew install git cmake automake autoconf libtool boost libjpeg graphviz
   sudo easy_install pip
   sudo pip install numpy
+  sudo pip install ipython --user
   sudo pip install -r requirements.txt --ignore-installed six
 fi
 pushd "$ROOT_DIR/thirdparty"


### PR DESCRIPTION
On Mac OS X, using the system's Python, the command
```
sudo pip install ipython
```
fails. However, the command
```
sudo pip install ipython --user
```
succeeds. That's why this commit installs ipython in user mode.

Would it be better to do all pip installs in user mode? Or to move the pip installs out of the setup script and have the user run them by hand (e.g., by copying from the readme)?

@jssmith @rshin