### PR TITLE
allow cluster script to update worker code on nodes

### DIFF
--- a/doc/using-ray-on-a-cluster.md
+++ b/doc/using-ray-on-a-cluster.md
@@ -45,30 +45,38 @@ until the installation has completed. The standard output from the nodes will
 be redirected to your terminal.
 5. To check that the installation succeeded, you can ssh to each node, cd into
 the directory `ray/test/`, and run the tests (e.g., `python runtest.py`).
-6. Now that Ray has been installed, you can start the cluster (the scheduler,
-object stores, and workers) with the command
-`start_ray("/home/ubuntu/ray/scripts/default_worker.py")`, where the second
-argument is the path on each node in the cluster to the worker code that you
-would like to use. After completing successfully, this command will print out a
-command that can be run on the head node to attach a shell (the driver) to the
-cluster. For example,
+6. Create a directory (for example, `mkdir ~/example_ray_code`) containing the
+worker `worker.py` code along with the code for any modules imported by
+`worker.py`. For example,
+
+    ```
+    cp ray/scripts/default_worker.py ~/example_ray_code/worker.py
+    cp ray/scripts/example_functions.py ~/example_ray_code/
+    ```
+
+7. Start the cluster (the scheduler, object stores, and workers) with the
+command `start_ray("~/example_ray_code")`, where the second argument is the
+local path to the worker code that you would like to use. This command will copy
+the worker code to each node and will start the cluster. After completing
+successfully, this command will print out a command that can be run on the head
+node to attach a shell (the driver) to the cluster. For example,
 
     ```
     source "$RAY_HOME/setup-env.sh";
-    python "$RAY_HOME/scripts/shell.py" --scheduler-address=52.50.28.103:10001 --objstore-address=52.50.28.103:20001 --worker-address=52.50.28.103:30001 --attach
+    python "$RAY_HOME/scripts/shell.py" --scheduler-address=12.34.56.789:10001 --objstore-address=12.34.56.789:20001 --worker-address=12.34.56.789:30001 --attach
     ```
 
-7. Note that there are several more commands that can be run from within
+8. Note that there are several more commands that can be run from within
 `cluster.py`.
 
     - `install_ray()` - This pulls the Ray source code on each node, builds all
       of the third party libraries, and builds the project itself.
-    - `start_ray(worker_path, num_workers_per_node=10)` - This starts a
+    - `start_ray(worker_directory, num_workers_per_node=10)` - This starts a
       scheduler process on the head node, and it starts an object store and some
       workers on each node.
     - `stop_ray()` - This shuts down the cluster (killing all of the processes).
-    - `restart_workers(worker_path, num_workers_per_node=10)` - This kills the
-      current workers and starts new workers using the worker code from the
+    - `restart_workers(worker_directory, num_workers_per_node=10)` - This kills
+      the current workers and starts new workers using the worker code from the
       given file. Currently, this can only run when there are no tasks currently
       executing on any of the workers.
     - `update_ray()` - This pulls the latest Ray source code and builds it.

--- a/lib/python/ray/services.py
+++ b/lib/python/ray/services.py
@@ -145,8 +145,6 @@ def start_node(scheduler_address, node_ip_address, num_workers, worker_path=None
   time.sleep(0.2)
   for _ in range(num_workers):
     start_worker(worker_path, scheduler_address, objstore_address, address(node_ip_address, new_worker_port()), local=False)
-  time.sleep(0.3)
-  ray.connect(scheduler_address, objstore_address, address(node_ip_address, new_worker_port()), is_driver=True)
   time.sleep(0.5)
 
 def start_workers(scheduler_address, objstore_address, num_workers, worker_path):


### PR DESCRIPTION
To try this out, do the following.
```
mkdir ~/example_worker_code
cp ray/scripts/default_worker.py ~/example_worker_code/worker.py
cp ray/scripts/example_functions.py ~/example_worker_code/
```
Then start `cluster.py` with
```
python cluster.py --nodes ... --key-file ... --username ... --installation-directory ...
```
Then start workers using the local code with.
```python
>>> start_ray("~/example_worker_code")
```
Try modifying `~/example_worker_code/example_functions.py` and then restarting the workers with
```python
>>> restart_workers("~/example_worker_code")
```
Note that if you ssh to any of the nodes in the cluster, you will find the worker code under `$installation_directory/ray_worker_files/`.