### PR TITLE
Added initial code for allowing python libraries to access objstore buffers

### DIFF
--- a/src/worker.h
+++ b/src/worker.h
@@ -61,6 +61,12 @@ class Worker {
   slice get_object(ObjRef objref);
   // stores an arrow object to the local object store
   PyObject* put_arrow(ObjRef objref, PyObject* array);
+  // Allocates buffer for objref with size of size
+  const char* allocate_buffer(ObjRef objref, int64_t size, SegmentId& segmentid);
+  // Finishes buffer with segmentid and an offset of metadata_ofset
+  PyObject* finish_buffer(ObjRef objref, SegmentId segmentid, int64_t metadata_offset);
+  // Gets the buffer for objref
+  const char* get_buffer(ObjRef objref, int64_t& size, SegmentId& segmentid);
   // gets an arrow object from the local object store
   PyObject* get_arrow(ObjRef objref, SegmentId& segmentid);
   // determine if the object stored in objref is an arrow object // TODO(pcm): more general mechanism for this?

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -136,6 +136,14 @@ class ObjStoreTest(unittest.TestCase):
     self.assertEqual(data[0], result[0])
     self.assertTrue(np.alltrue(data[1] == result[1]))
 
+    # Getting a buffer after modifying it before it finishes should return updated buffer
+    objref =  ray.lib.get_objref(w1.handle)
+    buf = ray.libraylib.allocate_buffer(w1.handle, objref, 100)
+    buf[0][0] = 1
+    ray.libraylib.finish_buffer(w1.handle, objref, buf[1], 0)
+    completedbuffer = ray.libraylib.get_buffer(w1.handle, objref)
+    self.assertEqual(completedbuffer[0][0], 1)
+
     ray.services.cleanup()
 
 class WorkerTest(unittest.TestCase):


### PR DESCRIPTION
Currently segfaults when calling `finish_buffer` when calling the code below:
```
temp =  ray.lib.get_objref(ray.worker.global_worker.handle)
buf = ray.libraylib.allocate_buffer(ray.worker.global_worker.handle, temp, 100)
ray.libraylib.finish_buffer(ray.worker.global_worker.handle, temp, buf[1], 0)
```