### PR TITLE
implement key value store for sharing reusable variables

### DIFF
--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -18,5 +18,6 @@ import config
 import libraylib as lib
 import serialization
 from worker import scheduler_info, visualize_computation_graph, task_info, register_module, connect, disconnect, get, put, remote, kill_workers, restart_workers_local
+from worker import Reusable, reusables
 from libraylib import ObjRef
 import internal

--- a/lib/python/ray/pickling.py
+++ b/lib/python/ray/pickling.py
@@ -1,5 +1,11 @@
 import cloudpickle
 
+def serialize(function):
+  return cloudpickle.dumps(function)
+
+def deserialize(serialized_function):
+  return cloudpickle.loads(serialized_function)
+
 def dumps(func, arg_types, return_types):
   return cloudpickle.dumps((func, arg_types, return_types))
 

--- a/protos/ray.proto
+++ b/protos/ray.proto
@@ -54,6 +54,8 @@ service Scheduler {
   rpc KillWorkers(KillWorkersRequest) returns (KillWorkersReply);
   // Exports function to the workers
   rpc ExportFunction(ExportFunctionRequest) returns (ExportFunctionReply);
+  // Ship an initializer and reinitializer for a reusable variable to the workers
+  rpc ExportReusableVariable(ExportReusableVariableRequest) returns (AckReply);
 }
 
 message AckReply {
@@ -237,6 +239,12 @@ message ExportFunctionRequest {
 message ExportFunctionReply {
 }
 
+message ExportReusableVariableRequest {
+  string name = 1; // The name of the reusable variable.
+  Function initializer = 2; // A serialized version of the function that initializes the reusable variable.
+  Function reinitializer = 3; // A serialized version of the function that reinitializes the reusable variable.
+}
+
 // These messages are for getting information about the object store state
 
 message ObjStoreInfoRequest {
@@ -253,6 +261,7 @@ message ObjStoreInfoReply {
 service WorkerService {
   rpc ExecuteTask(ExecuteTaskRequest) returns (ExecuteTaskReply); // Scheduler calls a function from the worker
   rpc ImportFunction(ImportFunctionRequest) returns (ImportFunctionReply); // Scheduler imports a function into the worker
+  rpc ImportReusableVariable(ImportReusableVariableRequest) returns (AckReply); // Scheduler imports a reusable variable into the worker
   rpc Die(DieRequest) returns (DieReply); // Kills this worker
 }
 
@@ -268,6 +277,12 @@ message ImportFunctionRequest {
 }
 
 message ImportFunctionReply {
+}
+
+message ImportReusableVariableRequest {
+  string name = 1; // The name of the reusable variable.
+  Function initializer = 2; // A serialized version of the function that initializes the reusable variable.
+  Function reinitializer = 3; // A serialized version of the function that reinitializes the reusable variable.
 }
 
 message DieRequest {

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -71,6 +71,7 @@ public:
   Status TaskInfo(ServerContext* context, const TaskInfoRequest* request, TaskInfoReply* reply) override;
   Status KillWorkers(ServerContext* context, const KillWorkersRequest* request, KillWorkersReply* reply) override;
   Status ExportFunction(ServerContext* context, const ExportFunctionRequest* request, ExportFunctionReply* reply) override;
+  Status ExportReusableVariable(ServerContext* context, const ExportReusableVariableRequest* request, AckReply* reply) override;
 
   // This will ask an object store to send an object to another object store if
   // the object is not already present in that object store and is not already

--- a/src/worker.h
+++ b/src/worker.h
@@ -23,9 +23,16 @@ using grpc::Channel;
 using grpc::ClientContext;
 using grpc::ClientWriter;
 
+struct ReusableVariable {
+  std::string variable_name;
+  std::string initializer;
+  std::string reinitializer;
+};
+
 struct WorkerMessage {
   Task task;
-  std::string function;
+  std::string function; // Used for importing remote functions.
+  ReusableVariable reusable_variable; // Used for importing reusable variables.
 };
 
 class WorkerServiceImpl final : public WorkerService::Service {
@@ -34,6 +41,7 @@ public:
   Status ExecuteTask(ServerContext* context, const ExecuteTaskRequest* request, ExecuteTaskReply* reply) override;
   Status ImportFunction(ServerContext* context, const ImportFunctionRequest* request, ImportFunctionReply* reply) override;
   Status Die(ServerContext* context, const DieRequest* request, DieReply* reply) override;
+  Status ImportReusableVariable(ServerContext* context, const ImportReusableVariableRequest* request, AckReply* reply) override;
 private:
   std::string worker_address_;
   MessageQueue<WorkerMessage*> send_queue_;
@@ -100,6 +108,8 @@ class Worker {
   void task_info(ClientContext &context, TaskInfoRequest &request, TaskInfoReply &reply);
   // export function to workers
   bool export_function(const std::string& function);
+  // export reusable variable to workers
+  void export_reusable_variable(const std::string& name, const std::string& initializer, const std::string& reinitializer);
 
  private:
   bool connected_;


### PR DESCRIPTION
Copied from the tests. You can use this code as follows (in `python scripts/shell.py`):

```python
def foo_initializer():
  return 1
def foo_reinitializer(foo):
  return foo

ray.reusables.foo = ray.Reusable(foo_initializer, foo_reinitializer)

@ray.remote([], [int])
def use_foo():
  return ray.reusables.foo

assert ray.reusables.foo == 1
assert ray.get(use_foo()) == 1
assert ray.get(use_foo()) == 1
assert ray.get(use_foo()) == 1

# Test that we can add a variable to the key-value store, mutate it, and reset it.

def bar_initializer():
  return [1, 2, 3]

ray.reusables.bar = ray.Reusable(bar_initializer)

@ray.remote([], [list])
def use_bar():
  ray.reusables.bar.append(4)
  return ray.reusables.bar

assert ray.get(use_bar()) == [1, 2, 3, 4]
assert ray.get(use_bar()) == [1, 2, 3, 4]
assert ray.get(use_bar()) == [1, 2, 3, 4]

# Test that we can use the reinitializer.

def baz_initializer():
  return np.zeros([4])
def baz_reinitializer(baz):
  for i in range(len(baz)):
    baz[i] = 0
  return baz

ray.reusables.baz = ray.Reusable(baz_initializer, baz_reinitializer)

@ray.remote([int], [np.ndarray])
def use_baz(i):
  baz = ray.reusables.baz
  baz[i] = 1
  return baz

assert np.alltrue(ray.get(use_baz(0)) == np.array([1, 0, 0, 0]))
assert np.alltrue(ray.get(use_baz(1)) == np.array([0, 1, 0, 0]))
assert np.alltrue(ray.get(use_baz(2)) == np.array([0, 0, 1, 0]))
assert np.alltrue(ray.get(use_baz(3)) == np.array([0, 0, 0, 1]))
```