### PR TITLE
Ray with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ estimate of pi (waiting until the computation has finished if necessary).
 
 ## Next Steps
 
-- Installation on [Ubuntu](doc/install-on-ubuntu.md), [Mac OS X](doc/install-on-macosx.md), [Windows](doc/install-on-windows.md)
+- Installation on [Ubuntu](doc/install-on-ubuntu.md), [Mac OS X](doc/install-on-macosx.md), [Windows](doc/install-on-windows.md), [Docker](doc/install-on-docker.md)
 - [Tutorial](doc/tutorial.md)
 - [About the System](doc/about-the-system.md)
 - [Using Ray on a Cluster](doc/using-ray-on-a-cluster.md)

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -2,3 +2,4 @@
 
 docker build -t amplab/ray:devel docker/devel
 docker build -t amplab/ray:deploy docker/deploy
+docker build -t amplab/ray:examples docker/examples

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t amplab/ray:devel docker/devel
+docker build -t amplab/ray:deploy docker/deploy

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -53,7 +53,7 @@ These steps apply only to Ray developers who prefer to use editing tools on the 
 Launch the developer container.
 
 ```
-docker run -v `pwd`:/home/ray/ray --shm-size=1024m  -t -i amplab/ray:devel
+docker run -v $(pwd):/home/ray-user/ray --shm-size=1024m  -t -i amplab/ray:devel
 ```
 
 Build Ray inside of the container.

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -1,0 +1,64 @@
+# Installation on Docker
+
+You can install Ray on any platform that runs Docker. We do not presently publish Docker images for Ray, but you can build them yourself using the Ray distribution. Using Docker can provide reliable way to get up and running quickly.
+
+## Install Docker
+
+The Docker Platform release is available for Mac, Windows, and Linux platforms. Please download the appropriate version from the [Docker website](https://www.docker.com/products/overview#/install_the_platform).
+
+## Clone the Ray repository
+
+```
+git clone https://github.com/amplab/ray.git
+```
+
+## Build Docker images
+
+Run the script to create Docker images.
+
+```
+cd ray
+./build-docker.sh
+```
+
+This script creates two Docker images, one for general use and deployment and one for development use.
+
+ * The `amplab/ray:deploy` has a self-contained copy of the code and is suitable for end users.
+ * Ray developers who want to edit locally on the host filesystem should use the `amplab/ray:devel` image, which allows local changes to be reflected immediately within the container. 
+
+## Launch Ray in Docker
+
+Start out by launching the deployment container.
+
+```
+docker run -ti amplab/ray:deploy
+```
+
+## Test if the installation succeeded
+
+To test if the installation was successful, try running some tests.
+
+```
+python test/runtest.py # This tests basic functionality.
+python test/array_test.py # This tests some array libraries.
+```
+
+You are now ready to continue with the [Tutorial](tutorial.md).
+
+## Developing with Docker
+
+These steps apply only to Ray developers who prefer to use editing tools on the host machine while building and running Ray within Docker. If you have previously been building locally we suggest that you start with a clean checkout before building with Ray's developer Docker container.
+
+Launch the developer container.
+
+```
+docker run -v `pwd`:/home/ray/ray -ti amplab/ray:devel 
+```
+
+Build Ray inside of the container.
+
+```
+cd ray
+./setup.sh
+./build.sh
+```

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -1,6 +1,6 @@
 # Installation on Docker
 
-You can install Ray on any platform that runs Docker. We do not presently publish Docker images for Ray, but you can build them yourself using the Ray distribution. Using Docker can provide reliable way to get up and running quickly.
+You can install Ray on any platform that runs Docker. We do not presently publish Docker images for Ray, but you can build them yourself using the Ray distribution. Using Docker can provide a reliable way to get up and running quickly.
 
 ## Install Docker
 

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -53,7 +53,7 @@ These steps apply only to Ray developers who prefer to use editing tools on the 
 Launch the developer container.
 
 ```
-docker run -v $(pwd):/home/ray-user/ray --shm-size=1024m  -t -i amplab/ray:devel
+docker run -v $(pwd):/home/ray-user/ray --shm-size=1024m -t -i amplab/ray:devel
 ```
 
 Build Ray inside of the container.
@@ -63,3 +63,5 @@ cd ray
 ./setup.sh
 ./build.sh
 ```
+
+Please we have seen occasional errors while running `setup.sh` on Mac OS X. If you have this problem please try re-running the script.

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -21,9 +21,10 @@ cd ray
 ./build-docker.sh
 ```
 
-This script creates two Docker images, one for general use and deployment and one for development use.
+This script creates several Docker images:
 
- * The `amplab/ray:deploy` has a self-contained copy of the code and is suitable for end users.
+ * The `amplab/ray:deploy` image is a self-contained copy of code and binaries suitable for end users.
+ * The `amplab/ray:examples` adds additional libraries for running examples.
  * Ray developers who want to edit locally on the host filesystem should use the `amplab/ray:devel` image, which allows local changes to be reflected immediately within the container. 
 
 ## Launch Ray in Docker
@@ -31,7 +32,7 @@ This script creates two Docker images, one for general use and deployment and on
 Start out by launching the deployment container.
 
 ```
-docker run -ti amplab/ray:deploy
+docker run --shm-size=1024m -t -i amplab/ray:deploy
 ```
 
 ## Test if the installation succeeded
@@ -52,7 +53,7 @@ These steps apply only to Ray developers who prefer to use editing tools on the 
 Launch the developer container.
 
 ```
-docker run -v `pwd`:/home/ray/ray -ti amplab/ray:devel 
+docker run -v `pwd`:/home/ray/ray --shm-size=1024m  -t -i amplab/ray:devel
 ```
 
 Build Ray inside of the container.

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -46,9 +46,50 @@ python test/array_test.py # This tests some array libraries.
 
 You are now ready to continue with the [Tutorial](tutorial.md).
 
+## Running examples in Docker
+
+Ray includes a Docker image that includes dependencies necessary for running some of the examples. This can be an easy way to see Ray in action on a variety of workloads.
+
+Launch the examples container.
+```
+docker run --shm-size=1024m -t -i amplab/ray:examples
+```
+
+### Hyperparameter optimization
+
+
+```
+cd ~/ray/examples/hyperopt/
+python driver.py
+```
+
+See the [Hyperparameter optimization documentation](../examples/hyperopt/README.md).
+
+### Batch L-BFGS
+
+```
+cd ~/ray/examples/lbfgs/
+python driver.py
+```
+
+See the [Batch L-BFGS documentation](../examples/lbfgs/README.md).
+
+### Learning to play Pong
+
+```
+cd ~/ray/examples/rl_pong/
+python driver.py
+```
+
+See the [Learning to play Pong documentation](../examples/rl_pong/README.md).
+
+
 ## Developing with Docker
 
 These steps apply only to Ray developers who prefer to use editing tools on the host machine while building and running Ray within Docker. If you have previously been building locally we suggest that you start with a clean checkout before building with Ray's developer Docker container.
+
+Please we have seen occasional errors while running `setup.sh` on Mac OS X. If you have this problem please try re-running the script. Increasing the memory of Docker's VM (say to 8GB from the default 2GB) seems to help.
+
 
 Launch the developer container.
 
@@ -63,5 +104,3 @@ cd ray
 ./setup.sh
 ./build.sh
 ```
-
-Please we have seen occasional errors while running `setup.sh` on Mac OS X. If you have this problem please try re-running the script.

--- a/doc/install-on-docker.md
+++ b/doc/install-on-docker.md
@@ -84,11 +84,11 @@ python driver.py
 See the [Learning to play Pong documentation](../examples/rl_pong/README.md).
 
 
-## Developing with Docker
+## Developing with Docker (Experimental)
 
 These steps apply only to Ray developers who prefer to use editing tools on the host machine while building and running Ray within Docker. If you have previously been building locally we suggest that you start with a clean checkout before building with Ray's developer Docker container.
 
-Please we have seen occasional errors while running `setup.sh` on Mac OS X. If you have this problem please try re-running the script. Increasing the memory of Docker's VM (say to 8GB from the default 2GB) seems to help.
+You may see errors while running `setup.sh` on Mac OS X. If you have this problem please try re-running the script. Increasing the memory of Docker's VM (say to 8GB from the default 2GB) seems to help.
 
 
 Launch the developer container.

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -4,14 +4,14 @@ RUN apt-get -y install apt-utils
 RUN apt-get -y install sudo
 RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
 RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
-RUN adduser --gecos --ingroup ray --disabled-login --gecos ray
-RUN adduser ray sudo
+RUN adduser --gecos --ingroup ray-user --disabled-login --gecos ray-user
+RUN adduser ray-user sudo
 RUN sed -i "s|%sudo\tALL=(ALL:ALL) ALL|%sudo\tALL=NOPASSWD: ALL|" /etc/sudoers
-USER ray
-WORKDIR /home/ray
+USER ray-user
+WORKDIR /home/ray-user
 RUN git clone https://github.com/amplab/ray
-WORKDIR /home/ray/ray
+WORKDIR /home/ray-user/ray
 RUN ./setup.sh
 RUN ./build.sh
-RUN echo '\n# Ray environment\nsource /home/ray/ray/setup-env.sh' >> /home/ray/.bashrc
+RUN echo '\n# Ray environment\nsource /home/ray-user/ray/setup-env.sh' >> /home/ray-user/.bashrc
 ENTRYPOINT bash

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:xenial
 RUN apt-get update
 RUN apt-get -y install apt-utils
 RUN apt-get -y install sudo
-RUN apt-get -y install git
 RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
 RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
 RUN adduser --gecos --ingroup ray --disabled-login --gecos ray

--- a/docker/deploy/Dockerfile
+++ b/docker/deploy/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:xenial
+RUN apt-get update
+RUN apt-get -y install apt-utils
+RUN apt-get -y install sudo
+RUN apt-get -y install git
+RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
+RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
+RUN adduser --gecos --ingroup ray --disabled-login --gecos ray
+RUN adduser ray sudo
+RUN sed -i "s|%sudo\tALL=(ALL:ALL) ALL|%sudo\tALL=NOPASSWD: ALL|" /etc/sudoers
+USER ray
+WORKDIR /home/ray
+RUN git clone https://github.com/amplab/ray
+WORKDIR /home/ray/ray
+RUN ./setup.sh
+RUN ./build.sh
+RUN echo '\n# Ray environment\nsource /home/ray/ray/setup-env.sh' >> /home/ray/.bashrc
+ENTRYPOINT bash

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -y install apt-utils
 RUN apt-get -y install sudo
 RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
 RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
-RUN adduser --gecos --ingroup ray-user --disabled-login --gecos ray-user --uid 1000
+RUN adduser --gecos --ingroup ray-user --disabled-login --gecos ray-user --uid 500
 RUN adduser ray-user sudo
 RUN sed -i "s|%sudo\tALL=(ALL:ALL) ALL|%sudo\tALL=NOPASSWD: ALL|" /etc/sudoers
 USER ray-user

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -4,10 +4,10 @@ RUN apt-get -y install apt-utils
 RUN apt-get -y install sudo
 RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
 RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
-RUN adduser --gecos --ingroup ray --disabled-login --gecos ray
-RUN adduser ray sudo
+RUN adduser --gecos --ingroup ray-user --disabled-login --gecos ray-user
+RUN adduser ray-user sudo
 RUN sed -i "s|%sudo\tALL=(ALL:ALL) ALL|%sudo\tALL=NOPASSWD: ALL|" /etc/sudoers
-USER ray
-RUN echo '\n# Ray environment\nsource /home/ray/ray/setup-env.sh' >> /home/ray/.bashrc
-WORKDIR /home/ray
+USER ray-user
+RUN echo '\n# Ray environment\nsource /home/ray-user/ray/setup-env.sh' >> /home/ray-user/.bashrc
+WORKDIR /home/ray-user
 ENTRYPOINT bash

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:xenial
+RUN apt-get update
+RUN apt-get -y install apt-utils
+RUN apt-get -y install sudo
+RUN apt-get -y install git
+RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
+RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
+RUN adduser --gecos --ingroup ray --disabled-login --gecos ray
+RUN adduser ray sudo
+RUN sed -i "s|%sudo\tALL=(ALL:ALL) ALL|%sudo\tALL=NOPASSWD: ALL|" /etc/sudoers
+USER ray
+RUN echo '\n# Ray environment\nsource /home/ray/ray/setup-env.sh' >> /home/ray/.bashrc
+WORKDIR /home/ray
+ENTRYPOINT bash

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:xenial
 RUN apt-get update
 RUN apt-get -y install apt-utils
 RUN apt-get -y install sudo
-RUN apt-get -y install git
 RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
 RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
 RUN adduser --gecos --ingroup ray --disabled-login --gecos ray

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -4,10 +4,12 @@ RUN apt-get -y install apt-utils
 RUN apt-get -y install sudo
 RUN apt-get install -y git cmake build-essential autoconf curl libtool python-dev python-numpy python-pip libboost-all-dev unzip graphviz
 RUN pip install ipython typing funcsigs subprocess32 protobuf==3.0.0a2 colorama graphviz cloudpickle
-RUN adduser --gecos --ingroup ray-user --disabled-login --gecos ray-user
+RUN adduser --gecos --ingroup ray-user --disabled-login --gecos ray-user --uid 1000
 RUN adduser ray-user sudo
 RUN sed -i "s|%sudo\tALL=(ALL:ALL) ALL|%sudo\tALL=NOPASSWD: ALL|" /etc/sudoers
 USER ray-user
-RUN echo '\n# Ray environment\nsource /home/ray-user/ray/setup-env.sh' >> /home/ray-user/.bashrc
 WORKDIR /home/ray-user
+RUN mkdir /home/ray-user/ray-build
+RUN mkdir /home/ray-user/ray
+RUN ln -s /home/ray-user/ray-build /home/ray-user/ray/build
 ENTRYPOINT bash

--- a/docker/examples/Dockerfile
+++ b/docker/examples/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install scipy
 
 # Gym
 RUN sudo apt-get -y install zlib1g-dev libjpeg-dev xvfb libav-tools xorg-dev python-opengl libsdl2-dev swig wget
-RUN pip install gym[all]
+RUN pip install gym[atari]

--- a/docker/examples/Dockerfile
+++ b/docker/examples/Dockerfile
@@ -1,0 +1,11 @@
+FROM amplab/ray:deploy
+
+# Tensorflow
+RUN pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp27-none-linux_x86_64.whl
+
+# SciPy
+RUN pip install scipy
+
+# Gym
+RUN sudo apt-get -y install zlib1g-dev libjpeg-dev xvfb libav-tools xorg-dev python-opengl libsdl2-dev swig wget
+RUN pip install gym[all]


### PR DESCRIPTION
This provides basic Docker functionality for Ray. Two Dockerfiles are included here: one that is fully contained and appropriate for end users, and another that mounts code from the local filesystem, as can be practical for developers. Cluster support and support for libraries required by examples is not part of this change.