### PR TITLE
Make sure no Python modules mutually import each other.

### DIFF
--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -1,12 +1,3 @@
-# These three constants are used to define the mode that a worker is running in.
-# Right now, this is only used for determining how to print information about
-# task failures.
-SCRIPT_MODE = 0
-WORKER_MODE = 1
-SHELL_MODE = 2
-PYTHON_MODE = 3
-SILENT_MODE = 4 # This is only used during testing.
-
 # Ray version string
 __version__ = "0.1"
 
@@ -19,9 +10,9 @@ if hasattr(ctypes, "windll"):
   (lambda kernel32: (lambda job: (lambda n: kernel32.SetInformationJobObject(job, 9, "\0" * 17 + chr(0x8 | 0x4 | 0x20) + "\0" * (n - 18), n))(0x90 if ctypes.sizeof(ctypes.c_void_p) > ctypes.sizeof(ctypes.c_int) else 0x70) and kernel32.AssignProcessToJobObject(job, ctypes.c_void_p(kernel32.GetCurrentProcess())))(ctypes.c_void_p(kernel32.CreateJobObjectW(None, None))) if kernel32 is not None else None)(ctypes.windll.kernel32)
 
 import config
-import libraylib as lib
 import serialization
 from worker import scheduler_info, visualize_computation_graph, task_info, register_module, init, connect, disconnect, get, put, remote, kill_workers, restart_workers_local
 from worker import Reusable, reusables
+from worker import SCRIPT_MODE, WORKER_MODE, SHELL_MODE, PYTHON_MODE, SILENT_MODE
 from libraylib import ObjectID
 import internal

--- a/lib/python/ray/serialization.py
+++ b/lib/python/ray/serialization.py
@@ -1,7 +1,7 @@
 import importlib
 import numpy as np
 
-import ray
+import libraylib as raylib
 
 # The following definitions are required because Python doesn't allow custom
 # attributes for primitive types. We need custom attributes for (a) implementing
@@ -54,18 +54,18 @@ def is_arrow_serializable(value):
 
 def serialize(worker_capsule, obj):
   primitive_obj = to_primitive(obj)
-  obj_capsule, contained_objectids = ray.lib.serialize_object(worker_capsule, primitive_obj) # contained_objectids is a list of the objectids contained in obj
+  obj_capsule, contained_objectids = raylib.serialize_object(worker_capsule, primitive_obj) # contained_objectids is a list of the objectids contained in obj
   return obj_capsule, contained_objectids
 
 def deserialize(worker_capsule, capsule):
-  primitive_obj = ray.lib.deserialize_object(worker_capsule, capsule)
+  primitive_obj = raylib.deserialize_object(worker_capsule, capsule)
   return from_primitive(primitive_obj)
 
 def serialize_task(worker_capsule, func_name, args):
-  primitive_args = [(arg if isinstance(arg, ray.ObjectID) else to_primitive(arg)) for arg in args]
-  return ray.lib.serialize_task(worker_capsule, func_name, primitive_args)
+  primitive_args = [(arg if isinstance(arg, raylib.ObjectID) else to_primitive(arg)) for arg in args]
+  return raylib.serialize_task(worker_capsule, func_name, primitive_args)
 
 def deserialize_task(worker_capsule, task):
   func_name, primitive_args, return_objectids = task
-  args = [(arg if isinstance(arg, ray.ObjectID) else from_primitive(arg)) for arg in primitive_args]
+  args = [(arg if isinstance(arg, raylib.ObjectID) else from_primitive(arg)) for arg in primitive_args]
   return func_name, args, return_objectids

--- a/test/array_test.py
+++ b/test/array_test.py
@@ -40,7 +40,7 @@ class RemoteArrayTest(unittest.TestCase):
     r_val = ray.get(r_id)
     self.assertTrue(np.allclose(np.dot(q_val, r_val), a_val))
 
-    ray.services.cleanup()
+    ray.worker.cleanup()
 
 class DistributedArrayTest(unittest.TestCase):
 
@@ -55,7 +55,7 @@ class DistributedArrayTest(unittest.TestCase):
     self.assertEqual(x.shape, y.shape)
     self.assertEqual(x.objectids[0, 0, 0].id, y.objectids[0, 0, 0].id)
 
-    ray.services.cleanup()
+    ray.worker.cleanup()
 
   def testAssemble(self):
     for module in [ra.core, ra.random, ra.linalg, da.core, da.random, da.linalg]:
@@ -67,13 +67,12 @@ class DistributedArrayTest(unittest.TestCase):
     x = da.DistArray([2 * da.BLOCK_SIZE, da.BLOCK_SIZE], np.array([[a], [b]]))
     self.assertTrue(np.alltrue(x.assemble() == np.vstack([np.ones([da.BLOCK_SIZE, da.BLOCK_SIZE]), np.zeros([da.BLOCK_SIZE, da.BLOCK_SIZE])])))
 
-    ray.services.cleanup()
+    ray.worker.cleanup()
 
   def testMethods(self):
     for module in [ra.core, ra.random, ra.linalg, da.core, da.random, da.linalg]:
       reload(module)
-    worker_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../scripts/default_worker.py")
-    ray.services.start_ray_local(num_objstores=2, num_workers_per_objstore=5, worker_path=worker_path)
+    ray.init(start_ray_local=True, num_objstores=2, num_workers=10)
 
     x = da.zeros.remote([9, 25, 51], "float")
     self.assertTrue(np.alltrue(ray.get(da.assemble.remote(x)) == np.zeros([9, 25, 51])))
@@ -207,7 +206,7 @@ class DistributedArrayTest(unittest.TestCase):
       d2 = np.random.randint(1, 35)
       test_dist_qr(d1, d2)
 
-    ray.services.cleanup()
+    ray.worker.cleanup()
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/memory_leak_deserialize.py
+++ b/test/memory_leak_deserialize.py
@@ -8,7 +8,7 @@ ray.init(start_ray_local=True, num_workers=1)
 
 d = {"w": np.zeros(1000000)}
 
-obj_capsule, contained_objectids = ray.lib.serialize_object(ray.worker.global_worker.handle, d)
+obj_capsule, contained_objectids = ray.libraylib.serialize_object(ray.worker.global_worker.handle, d)
 
 while True:
-  ray.lib.deserialize_object(ray.worker.global_worker.handle, obj_capsule)
+  ray.libraylib.deserialize_object(ray.worker.global_worker.handle, obj_capsule)

--- a/test/microbenchmarks.py
+++ b/test/microbenchmarks.py
@@ -77,7 +77,7 @@ class MicroBenchmarkTest(unittest.TestCase):
     print "    worst:           {}".format(elapsed_times[999])
     # average_elapsed_time should be about 0.00087
 
-    ray.services.cleanup()
+    ray.worker.cleanup()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This cleans up some of the imports and also addresses #332.

This PR also changes `ray.services.start_ray_local` a bit. That command used to start a scheduler, an object store, some workers, and it would also connect the driver. Now it just starts a scheduler, an object store, and some workers. Connecting to the driver must be done separately (it is done in `worker.py` by `ray.init`.