### PR TITLE
Only display failed task information for new tasks, remove SHELL_MODE

### DIFF
--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -13,6 +13,6 @@ import config
 import serialization
 from worker import scheduler_info, visualize_computation_graph, task_info, register_module, init, connect, disconnect, get, put, remote, kill_workers, restart_workers_local
 from worker import Reusable, reusables
-from worker import SCRIPT_MODE, WORKER_MODE, SHELL_MODE, PYTHON_MODE, SILENT_MODE
+from worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from libraylib import ObjectID
 import internal


### PR DESCRIPTION
Before this PR, if a task failed. It's error message would be printed every single time the user did something. This change makes it so that the error message is only printed a single time. The error information is still accessible through `ray.task_info()`.

Run the following.

```python
import ray
ray.init(start_ray_local=True, num_workers=1)

@ray.remote([], [int])
def f():
  raise Exception("Failure!!!")

f.remote()
```

Then a call to `ray.put(3)` will print

```python
    Error: Task failed
      Function Name: __main__.f
      Task ID: 3
      Error Message: 
          Traceback (most recent call last):
            File "<ipython-input-7-314529bcd714>", line 3, in f
          Exception: Failure!!!
          
  
Error: 1 new task failed.
```

A subsequent call to `ray.put(3)` will not print any error messages.