### PR TITLE
update rnn example

### DIFF
--- a/examples/rnn/rnn.py
+++ b/examples/rnn/rnn.py
@@ -1,0 +1,114 @@
+import ray
+import numpy as np
+import tensorflow as tf
+
+scale = 200
+num_steps = 10
+
+batch_size = scale - 1
+xdim = scale * 10
+h1dim = (scale + 1) * 10
+h2dim = (scale + 2) * 10
+h3dim = (scale + 3) * 10
+h4dim = (scale + 4) * 10
+h5dim = (scale + 5) * 10
+ydim = (2 * scale + 6) * 10
+
+
+def net_initialization():
+  x_in = tf.placeholder(tf.float32, [batch_size, xdim])
+  h1_in = tf.placeholder(tf.float32, [batch_size, h1dim])
+  h2_in = tf.placeholder(tf.float32, [batch_size, h2dim])
+  h3_in = tf.placeholder(tf.float32, [batch_size, h3dim])
+  h4_in = tf.placeholder(tf.float32, [batch_size, h4dim])
+  h5_in = tf.placeholder(tf.float32, [batch_size, h5dim])
+
+  W1_p = tf.Variable(tf.truncated_normal([xdim, h1dim]))
+  W1_h = tf.Variable(tf.truncated_normal([h1dim, h1dim]))
+
+  W2_p = tf.Variable(tf.truncated_normal([h1dim, h2dim]))
+  W2_h = tf.Variable(tf.truncated_normal([h2dim, h2dim]))
+
+  W3_p = tf.Variable(tf.truncated_normal([h2dim, h3dim]))
+  W3_h = tf.Variable(tf.truncated_normal([h3dim, h3dim]))
+
+  W4_p = tf.Variable(tf.truncated_normal([h3dim, h4dim]))
+  W4_h = tf.Variable(tf.truncated_normal([h4dim, h4dim]))
+
+  W5_p = tf.Variable(tf.truncated_normal([h4dim, h5dim]))
+  W5_h = tf.Variable(tf.truncated_normal([h5dim, h5dim]))
+
+  W6_p = tf.Variable(tf.truncated_normal([h5dim, ydim]))
+
+  h1 = tf.matmul(x_in, W1_p) + tf.matmul(h1_in, W1_h)
+  h2 = tf.matmul(h1_in, W2_p) + tf.matmul(h2_in, W2_h)
+  h3 = tf.matmul(h2_in, W3_p) + tf.matmul(h3_in, W3_h)
+  h4 = tf.matmul(h3_in, W4_p) + tf.matmul(h4_in, W4_h)
+  h5 = tf.matmul(h4_in, W5_p) + tf.matmul(h5_in, W5_h)
+  y = tf.matmul(h5_in, W6_p)
+
+
+  init = tf.initialize_all_variables()
+  sess = tf.Session()
+  sess.run(init)
+
+  return sess, h1, h2, h3, h4, h5, y, x_in, h1_in, h2_in, h3_in, h4_in, h5_in
+
+def net_reinitialization(net_vars):
+  return net_vars
+
+mono_net_vars = []
+
+@ray.remote([np.ndarray, np.ndarray], [np.ndarray])
+def first_layer(x_val, h1_val):
+  sess, h1, _, _, _, _, _, x_in, h1_in, _, _, _, _ = ray.reusables.net_vars
+  return sess.run(h1, feed_dict={x_in: x_val, h1_in: h1_val})
+
+@ray.remote([np.ndarray, np.ndarray], [np.ndarray])
+def second_layer(h1_val, h2_val):
+  sess, _, h2, _, _, _, _, _, h1_in, h2_in, _, _, _ = ray.reusables.net_vars
+  return sess.run(h2, feed_dict={h1_in: h1_val, h2_in: h2_val})
+
+@ray.remote([np.ndarray, np.ndarray], [np.ndarray])
+def third_layer(h2_val, h3_val):
+  sess, _, _, h3, _, _, _, _, _, h2_in, h3_in, _, _ = ray.reusables.net_vars
+  return sess.run(h3, feed_dict={h2_in: h2_val, h3_in: h3_val})
+
+@ray.remote([np.ndarray, np.ndarray], [np.ndarray])
+def fourth_layer(h3_val, h4_val):
+  sess, _, _, _, h4, _, _, _, _, _, h3_in, h4_in, _ = ray.reusables.net_vars
+  return sess.run(h4, feed_dict={h3_in: h3_val, h4_in: h4_val})
+
+@ray.remote([np.ndarray, np.ndarray], [np.ndarray])
+def fifth_layer(h4_val, h5_val):
+  sess, _, _, _, _, h5, _, _, _, _, _, h4_in, h5_in = ray.reusables.net_vars
+  return sess.run(h5, feed_dict={h4_in: h4_val, h5_in: h5_val})
+
+@ray.remote([np.ndarray], [np.ndarray])
+def sixth_layer(h5_val):
+  sess, _, _, _, _, _, y, _, _, _, _, _, h5_in = ray.reusables.net_vars
+  return sess.run(y, feed_dict={h5_in: h5_val})
+
+def first_layer_mono(x_val, h1_val):
+  sess, h1, _, _, _, _, _, x_in, h1_in, _, _, _, _ = mono_net_vars
+  return sess.run(h1, feed_dict={x_in: x_val, h1_in: h1_val})
+
+def second_layer_mono(h1_val, h2_val):
+  sess, _, h2, _, _, _, _, _, h1_in, h2_in, _, _, _ = mono_net_vars
+  return sess.run(h2, feed_dict={h1_in: h1_val, h2_in: h2_val})
+
+def third_layer_mono(h2_val, h3_val):
+  sess, _, _, h3, _, _, _, _, _, h2_in, h3_in, _, _ = mono_net_vars
+  return sess.run(h3, feed_dict={h2_in: h2_val, h3_in: h3_val})
+
+def fourth_layer_mono(h3_val, h4_val):
+  sess, _, _, _, h4, _, _, _, _, _, h3_in, h4_in, _ = mono_net_vars
+  return sess.run(h4, feed_dict={h3_in: h3_val, h4_in: h4_val})
+
+def fifth_layer_mono(h4_val, h5_val):
+  sess, _, _, _, _, h5, _, _, _, _, _, h4_in, h5_in = mono_net_vars
+  return sess.run(h5, feed_dict={h4_in: h4_val, h5_in: h5_val})
+
+def sixth_layer_mono(h5_val):
+  sess, _, _, _, _, _, y, _, _, _, _, _, h5_in = mono_net_vars
+  return sess.run(y, feed_dict={h5_in: h5_val})

--- a/examples/rnn/rnn_monolithic.py
+++ b/examples/rnn/rnn_monolithic.py
@@ -1,0 +1,75 @@
+import rnn
+import tensorflow as tf
+import numpy as np
+import time
+
+# Run monolithic RNN
+
+W1_p = tf.Variable(tf.truncated_normal([rnn.xdim, rnn.h1dim]))
+W1_h = tf.Variable(tf.truncated_normal([rnn.h1dim, rnn.h1dim]))
+
+W2_p = tf.Variable(tf.truncated_normal([rnn.h1dim, rnn.h2dim]))
+W2_h = tf.Variable(tf.truncated_normal([rnn.h2dim, rnn.h2dim]))
+
+W3_p = tf.Variable(tf.truncated_normal([rnn.h2dim, rnn.h3dim]))
+W3_h = tf.Variable(tf.truncated_normal([rnn.h3dim, rnn.h3dim]))
+
+W4_p = tf.Variable(tf.truncated_normal([rnn.h3dim, rnn.h4dim]))
+W4_h = tf.Variable(tf.truncated_normal([rnn.h4dim, rnn.h4dim]))
+
+W5_p = tf.Variable(tf.truncated_normal([rnn.h4dim, rnn.h5dim]))
+W5_h = tf.Variable(tf.truncated_normal([rnn.h5dim, rnn.h5dim]))
+
+W6_p = tf.Variable(tf.truncated_normal([rnn.h5dim, rnn.ydim]))
+
+h1_mono = tf.Variable(tf.zeros([rnn.batch_size, rnn.h1dim]))
+h2_mono = tf.Variable(tf.zeros([rnn.batch_size, rnn.h2dim]))
+h3_mono = tf.Variable(tf.zeros([rnn.batch_size, rnn.h3dim]))
+h4_mono = tf.Variable(tf.zeros([rnn.batch_size, rnn.h4dim]))
+h5_mono = tf.Variable(tf.zeros([rnn.batch_size, rnn.h5dim]))
+inputs_monolithic = [tf.placeholder(tf.float32, [rnn.batch_size, rnn.xdim]) for _ in range(rnn.num_steps)]
+y_monolithic = []
+for t in range(rnn.num_steps):
+  h1_mono = tf.matmul(inputs_monolithic[t], W1_p) + tf.matmul(h1_mono, W1_h)
+  h2_mono = tf.matmul(h1_mono, W2_p) + tf.matmul(h2_mono, W2_h)
+  h3_mono = tf.matmul(h2_mono, W3_p) + tf.matmul(h3_mono, W3_h)
+  h4_mono = tf.matmul(h3_mono, W4_p) + tf.matmul(h4_mono, W4_h)
+  h5_mono = tf.matmul(h4_mono, W5_p) + tf.matmul(h5_mono, W5_h)
+  y_monolithic.append(tf.matmul(h5_mono, W6_p))
+
+init = tf.initialize_all_variables()
+sess = tf.Session()
+sess.run(init)
+
+inputs = [np.random.normal(size=[rnn.batch_size, rnn.xdim]) for _ in range(rnn.num_steps)]
+feed_dict = dict(zip(inputs_monolithic, inputs))
+
+start_time = time.time()
+outputs = sess.run(h1_mono, feed_dict=feed_dict)
+end_time = time.time()
+print "Monolithic RNN, 1 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = sess.run(h2_mono, feed_dict=feed_dict)
+end_time = time.time()
+print "Monolithic RNN, 2 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = sess.run(h3_mono, feed_dict=feed_dict)
+end_time = time.time()
+print "Monolithic RNN, 3 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = sess.run(h4_mono, feed_dict=feed_dict)
+end_time = time.time()
+print "Monolithic RNN, 4 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = sess.run(h5_mono, feed_dict=feed_dict)
+end_time = time.time()
+print "Monolithic RNN, 5 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = sess.run(y_monolithic, feed_dict=feed_dict)
+end_time = time.time()
+print "Monolithic RNN, 6 layer, elapsed_time = {} seconds.".format(end_time - start_time)

--- a/examples/rnn/rnn_monolithic_task.py
+++ b/examples/rnn/rnn_monolithic_task.py
@@ -1,0 +1,67 @@
+import rnn
+import numpy as np
+import time
+
+rnn.mono_net_vars = rnn.net_initialization()
+
+# Run monolithic task RNN
+h1 = np.zeros([rnn.batch_size, rnn.h1dim])
+h2 = np.zeros([rnn.batch_size, rnn.h2dim])
+h3 = np.zeros([rnn.batch_size, rnn.h3dim])
+h4 = np.zeros([rnn.batch_size, rnn.h4dim])
+h5 = np.zeros([rnn.batch_size, rnn.h5dim])
+
+inputs = [np.random.normal(size=[rnn.batch_size, rnn.xdim]) for _ in range(rnn.num_steps)]
+
+# Run monolithic task RNN
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer_mono(inputs[t], h1)
+end_time = time.time()
+print "Monolithic Task RNN, 1 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer_mono(inputs[t], h1)
+  h2 = rnn.second_layer_mono(h1, h2)
+end_time = time.time()
+print "Monolithic Task RNN, 2 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer_mono(inputs[t], h1)
+  h2 = rnn.second_layer_mono(h1, h2)
+  h3 = rnn.third_layer_mono(h2, h3)
+end_time = time.time()
+print "Monolithic Task RNN, 3 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer_mono(inputs[t], h1)
+  h2 = rnn.second_layer_mono(h1, h2)
+  h3 = rnn.third_layer_mono(h2, h3)
+  h4 = rnn.fourth_layer_mono(h3, h4)
+end_time = time.time()
+print "Monolithic Task RNN, 4 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer_mono(inputs[t], h1)
+  h2 = rnn.second_layer_mono(h1, h2)
+  h3 = rnn.third_layer_mono(h2, h3)
+  h4 = rnn.fourth_layer_mono(h3, h4)
+  h5 = rnn.fifth_layer_mono(h4, h5)
+end_time = time.time()
+print "Monolithic Task RNN, 5 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = []
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer_mono(inputs[t], h1)
+  h2 = rnn.second_layer_mono(h1, h2)
+  h3 = rnn.third_layer_mono(h2, h3)
+  h4 = rnn.fourth_layer_mono(h3, h4)
+  h5 = rnn.fifth_layer_mono(h4, h5)
+  outputs.append(rnn.sixth_layer_mono(h5))
+end_time = time.time()
+print "Monolithic Task RNN, 6 layer, elapsed_time = {} seconds.".format(end_time - start_time)

--- a/examples/rnn/rnn_ray.py
+++ b/examples/rnn/rnn_ray.py
@@ -1,0 +1,75 @@
+import ray
+import rnn
+import time
+import ray.array.remote as ra
+
+ray.init(start_ray_local=True, num_workers=10)
+ray.reusables.net_vars = ray.Reusable(rnn.net_initialization, rnn.net_reinitialization)
+
+h1 = ra.zeros.remote([rnn.batch_size, rnn.h1dim])
+h2 = ra.zeros.remote([rnn.batch_size, rnn.h2dim])
+h3 = ra.zeros.remote([rnn.batch_size, rnn.h3dim])
+h4 = ra.zeros.remote([rnn.batch_size, rnn.h4dim])
+h5 = ra.zeros.remote([rnn.batch_size, rnn.h5dim])
+
+inputs = [ra.random.normal.remote([rnn.batch_size, rnn.xdim]) for _ in range(rnn.num_steps)]
+
+# Run distributed RNN
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer.remote(inputs[t], h1)
+ray.get(h1)
+end_time = time.time()
+print "Distributed RNN, 1 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer.remote(inputs[t], h1)
+  h2 = rnn.second_layer.remote(h1, h2)
+ray.get(h2)
+end_time = time.time()
+print "Distributed RNN, 2 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer.remote(inputs[t], h1)
+  h2 = rnn.second_layer.remote(h1, h2)
+  h3 = rnn.third_layer.remote(h2, h3)
+ray.get(h3)
+end_time = time.time()
+print "Distributed RNN, 3 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer.remote(inputs[t], h1)
+  h2 = rnn.second_layer.remote(h1, h2)
+  h3 = rnn.third_layer.remote(h2, h3)
+  h4 = rnn.fourth_layer.remote(h3, h4)
+ray.get(h4)
+end_time = time.time()
+print "Distributed RNN, 4 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer.remote(inputs[t], h1)
+  h2 = rnn.second_layer.remote(h1, h2)
+  h3 = rnn.third_layer.remote(h2, h3)
+  h4 = rnn.fourth_layer.remote(h3, h4)
+  h5 = rnn.fifth_layer.remote(h4, h5)
+ray.get(h5)
+end_time = time.time()
+print "Distributed RNN, 5 layer, elapsed_time = {} seconds.".format(end_time - start_time)
+
+start_time = time.time()
+outputs = []
+for t in range(rnn.num_steps):
+  h1 = rnn.first_layer.remote(inputs[t], h1)
+  h2 = rnn.second_layer.remote(h1, h2)
+  h3 = rnn.third_layer.remote(h2, h3)
+  h4 = rnn.fourth_layer.remote(h3, h4)
+  h5 = rnn.fifth_layer.remote(h4, h5)
+  outputs.append(rnn.sixth_layer.remote(h5))
+for t in range(rnn.num_steps):
+  ray.get(outputs[t])
+end_time = time.time()
+print "Distributed RNN, 6 layer, elapsed_time = {} seconds.".format(end_time - start_time)


### PR DESCRIPTION
This change reintroduces an old example, a recurrent neural network that demonstrates the flexibility of Ray's scheduling. I have updated the code to match the latest Ray API. In addition, there are now several separate scripts:

- `rnn_monolithic.py` is an idiomatic Tensorflow implementations
- `rnn_ray.py` is distributed implementation for Ray
- `rnn_monolithic_task.py` does not use Ray, but structures the computation as we do for Ray

I have also reduced the size of the computation so that it runs in an 8GB vm instance.

At this point I am seeking feedback rather than an immediate merge. I would like to structure this example like the others, where there is a `driver.py` file. I imagine that the `driver.py` will just run the test under Ray, whereas we can provide other scripts for running the comparisons to other implementations. Additional tasks remaining include adding documentation and adding this example to the continuous integration test suite.