### PR TITLE
Catch errors in importing reusable variables and remote functions

### DIFF
--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -13,6 +13,6 @@ import config
 import serialization
 from worker import scheduler_info, visualize_computation_graph, task_info, init, connect, disconnect, get, put, remote, kill_workers, restart_workers_local
 from worker import Reusable, reusables
-from worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
+from libraylib import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from libraylib import ObjectID
 import internal

--- a/lib/python/ray/__init__.py
+++ b/lib/python/ray/__init__.py
@@ -11,7 +11,7 @@ if hasattr(ctypes, "windll"):
 
 import config
 import serialization
-from worker import scheduler_info, visualize_computation_graph, task_info, register_module, init, connect, disconnect, get, put, remote, kill_workers, restart_workers_local
+from worker import scheduler_info, visualize_computation_graph, task_info, init, connect, disconnect, get, put, remote, kill_workers, restart_workers_local
 from worker import Reusable, reusables
 from worker import SCRIPT_MODE, WORKER_MODE, PYTHON_MODE, SILENT_MODE
 from libraylib import ObjectID

--- a/protos/ray.proto
+++ b/protos/ray.proto
@@ -22,8 +22,8 @@ service Scheduler {
   rpc RegisterWorker(RegisterWorkerRequest) returns (RegisterWorkerReply);
   // Register an object store with the scheduler
   rpc RegisterObjStore(RegisterObjStoreRequest) returns (RegisterObjStoreReply);
-  // Tell the scheduler that a worker can execute a certain function
-  rpc RegisterFunction(RegisterFunctionRequest) returns (AckReply);
+  // Tell the scheduler that a worker successfully imported a remote function.
+  rpc RegisterRemoteFunction(RegisterRemoteFunctionRequest) returns (AckReply);
   // Asks the scheduler to execute a task, immediately returns an object ID to the result
   rpc SubmitTask(SubmitTaskRequest) returns (SubmitTaskReply);
   // Increment the count of the object ID
@@ -53,9 +53,11 @@ service Scheduler {
   // Kills the workers
   rpc KillWorkers(KillWorkersRequest) returns (KillWorkersReply);
   // Exports function to the workers
-  rpc ExportFunction(ExportFunctionRequest) returns (ExportFunctionReply);
+  rpc ExportRemoteFunction(ExportRemoteFunctionRequest) returns (AckReply);
   // Ship an initializer and reinitializer for a reusable variable to the workers
   rpc ExportReusableVariable(ExportReusableVariableRequest) returns (AckReply);
+  // Notify the scheduler that a failure occurred while running a task, importing a remote function, or importing a reusable variable.
+  rpc NotifyFailure(NotifyFailureRequest) returns (AckReply);
 }
 
 message AckReply {
@@ -82,10 +84,14 @@ message RegisterObjStoreReply {
   uint64 objstoreid = 1; // Object store ID assigned by the scheduler
 }
 
-message RegisterFunctionRequest {
+message RegisterRemoteFunctionRequest {
   uint64 workerid = 1; // Worker that can execute the function
-  string fnname = 2; // Name of the function that is registered
-  uint64 num_return_vals = 3; // Number of return values of the function
+  string function_name = 2; // Name of the remote function
+  uint64 num_return_vals = 3; // Number of return values of the function. This is only present if the function was successfully imported.
+}
+
+message NotifyFailure {
+  Failure failure = 1; // The failure object.
 }
 
 message SubmitTaskRequest {
@@ -136,11 +142,6 @@ message DecrementRefCountRequest {
 
 message ReadyForNewTaskRequest {
   uint64 workerid = 1; // ID of the worker which executed the task
-  message PreviousTaskInfo {
-    bool task_succeeded = 1; // True if the task succeeded, false if it threw an exception
-    string error_message = 2; // The contents of the exception, if the task threw an exception
-  }
-  PreviousTaskInfo previous_task_info = 2; // Information about the previous task, this is only present if there was a previous task
 }
 
 message ChangeCountRequest {
@@ -221,10 +222,11 @@ message TaskInfoRequest {
 }
 
 message TaskInfoReply {
-  repeated TaskStatus failed_task = 1;
-  repeated TaskStatus running_task = 2;
-  uint64 num_succeeded = 3;
-  // TODO(mehrdadn): We'll want to return information from computation_graph since it's important for visualizing tasks that have been completed etc.
+  repeated TaskStatus failed_task = 1; // The tasks that have failed.
+  repeated TaskStatus running_task = 2; // The tasks that are currently running.
+  repeated Failure failed_remote_function_import = 3; // The remote function imports that failed.
+  repeated Failure failed_reusable_variable_import = 4; // The reusable variable imports that failed.
+  repeated Failure failed_reinitialize_reusable_variable = 5; // The reusable variable reinitializations that failed.
 }
 
 message KillWorkersRequest {
@@ -234,15 +236,16 @@ message KillWorkersReply {
   bool success = 1;  // Currently, the only reason to fail is if there are workers still executing tasks
 }
 
-message ExportFunctionRequest {
+message ExportRemoteFunctionRequest {
   Function function = 1;
-}
-
-message ExportFunctionReply {
 }
 
 message ExportReusableVariableRequest {
   ReusableVar reusable_variable = 1; // The reusable variable to export.
+}
+
+message NotifyFailureRequest {
+  Failure failure = 1; // The failure object.
 }
 
 // These messages are for getting information about the object store state
@@ -259,24 +262,19 @@ message ObjStoreInfoReply {
 // Workers
 
 service WorkerService {
-  rpc ExecuteTask(ExecuteTaskRequest) returns (ExecuteTaskReply); // Scheduler calls a function from the worker
-  rpc ImportFunction(ImportFunctionRequest) returns (ImportFunctionReply); // Scheduler imports a function into the worker
+  rpc ExecuteTask(ExecuteTaskRequest) returns (AckReply); // Scheduler calls a function from the worker
+  rpc ImportRemoteFunction(ImportRemoteFunctionRequest) returns (AckReply); // Scheduler imports a function into the worker
   rpc ImportReusableVariable(ImportReusableVariableRequest) returns (AckReply); // Scheduler imports a reusable variable into the worker
-  rpc Die(DieRequest) returns (DieReply); // Kills this worker
+  rpc Die(DieRequest) returns (AckReply); // Kills this worker
+  rpc PrintErrorMessage(PrintErrorMessageRequest) returns (AckReply); // Causes an error message to be printed.
 }
 
 message ExecuteTaskRequest {
   Task task = 1; // Contains name of the function to be executed and arguments
 }
 
-message ExecuteTaskReply {
-}
-
-message ImportFunctionRequest {
+message ImportRemoteFunctionRequest {
   Function function = 1;
-}
-
-message ImportFunctionReply {
 }
 
 message ImportReusableVariableRequest {
@@ -284,9 +282,6 @@ message ImportReusableVariableRequest {
 }
 
 message DieRequest {
-}
-
-message DieReply {
 }
 
 // This message is used by the worker service to send messages to the worker
@@ -297,4 +292,8 @@ message WorkerMessage {
     Function function = 2; // A remote function to import on the worker.
     ReusableVar reusable_variable = 3; // A reusable variable to import on the worker.
   }
+}
+
+message PrintErrorMessageRequest {
+  Failure failure = 1; // The failure object.
 }

--- a/protos/types.proto
+++ b/protos/types.proto
@@ -38,13 +38,32 @@ message PyObj {
 
 // Used for shipping remote functions to workers
 message Function {
-  bytes implementation = 1;
+  string name = 1;
+  bytes implementation = 2;
 }
 
 message ReusableVar {
   string name = 1; // The name of the reusable variable.
   Function initializer = 2; // A serialized version of the function that initializes the reusable variable.
   Function reinitializer = 3; // A serialized version of the function that reinitializes the reusable variable.
+}
+
+enum FailedType {
+  FailedTask = 0;
+  FailedRemoteFunctionImport = 1;
+  FailedReusableVariableImport = 2;
+  FailedReinitializeReusableVariable = 3;
+}
+
+// Used to represent exceptions thrown in Python. This will happen when a task
+// fails to execute, a remote function fails to be imported, or a reusable
+// variable fails to be imported.
+message Failure {
+  FailedType type = 1; // The type of the failure.
+  uint64 workerid = 2; // The id of the worker on which the failure occurred.
+  string worker_address = 3; // The address of the worker on which the failure occurred. This contains the same information as the workerid.
+  string name = 4; // The name of the failed object.
+  string error_message = 5; // The error message from the failure.
 }
 
 // Union of possible object types

--- a/src/raylib.cc
+++ b/src/raylib.cc
@@ -715,7 +715,10 @@ static PyObject* wait_for_next_message(PyObject* self, PyObject* args) {
       PyTuple_SetItem(t, 1, deserialize_task(worker_capsule, message->task()));
     } else if (function_present) {
       PyTuple_SetItem(t, 0, PyString_FromString("function"));
-      PyTuple_SetItem(t, 1, PyString_FromStringAndSize(message->function().implementation().data(), static_cast<ssize_t>(message->function().implementation().size())));
+      PyObject* remote_function_data = PyTuple_New(2);
+      PyTuple_SetItem(remote_function_data, 0, PyString_FromStringAndSize(message->function().name().data(), static_cast<ssize_t>(message->function().name().size())));
+      PyTuple_SetItem(remote_function_data, 1, PyString_FromStringAndSize(message->function().implementation().data(), static_cast<ssize_t>(message->function().implementation().size())));
+      PyTuple_SetItem(t, 1, remote_function_data);
     } else if (reusable_variable_present) {
       PyTuple_SetItem(t, 0, PyString_FromString("reusable_variable"));
       PyObject* reusable_variable = PyTuple_New(3);
@@ -734,14 +737,15 @@ static PyObject* wait_for_next_message(PyObject* self, PyObject* args) {
   Py_RETURN_NONE;
 }
 
-static PyObject* export_function(PyObject* self, PyObject* args) {
+static PyObject* export_remote_function(PyObject* self, PyObject* args) {
   Worker* worker;
+  const char* function_name;
   const char* function;
   int function_size;
-  if (!PyArg_ParseTuple(args, "O&s#", &PyObjectToWorker, &worker, &function, &function_size)) {
+  if (!PyArg_ParseTuple(args, "O&ss#", &PyObjectToWorker, &worker, &function_name, &function, &function_size)) {
     return NULL;
   }
-  if (worker->export_function(std::string(function, static_cast<size_t>(function_size)))) {
+  if (worker->export_remote_function(std::string(function_name), std::string(function, static_cast<size_t>(function_size)))) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;
@@ -795,25 +799,65 @@ static PyObject* submit_task(PyObject* self, PyObject* args) {
 
 static PyObject* notify_task_completed(PyObject* self, PyObject* args) {
   Worker* worker;
-  PyObject* task_succeeded_obj;
-  const char* error_message_ptr;
-  if (!PyArg_ParseTuple(args, "O&Os", &PyObjectToWorker, &worker, &task_succeeded_obj, &error_message_ptr)) {
+  if (!PyArg_ParseTuple(args, "O&", &PyObjectToWorker, &worker)) {
     return NULL;
   }
-  std::string error_message(error_message_ptr);
-  bool task_succeeded = PyObject_IsTrue(task_succeeded_obj);
-  worker->notify_task_completed(task_succeeded, error_message);
+  worker->notify_task_completed();
   Py_RETURN_NONE;
 }
 
-static PyObject* register_function(PyObject* self, PyObject* args) {
+static PyObject* register_remote_function(PyObject* self, PyObject* args) {
   Worker* worker;
   const char* function_name;
   int num_return_vals;
   if (!PyArg_ParseTuple(args, "O&si", &PyObjectToWorker, &worker, &function_name, &num_return_vals)) {
     return NULL;
   }
-  worker->register_function(std::string(function_name), num_return_vals);
+  worker->register_remote_function(std::string(function_name), num_return_vals);
+  Py_RETURN_NONE;
+}
+
+static PyObject* notify_task_failure(PyObject* self, PyObject* args) {
+  Worker* worker;
+  const char* function_name;
+  const char* error_message;
+  if (!PyArg_ParseTuple(args, "O&ss", &PyObjectToWorker, &worker, &function_name, &error_message)) {
+    return NULL;
+  }
+  worker->notify_failure(FailedType::FailedTask, std::string(function_name), std::string(error_message));
+  Py_RETURN_NONE;
+}
+
+static PyObject* notify_remote_function_import_failure(PyObject* self, PyObject* args) {
+  Worker* worker;
+  const char* remote_function_name;
+  const char* error_message;
+  if (!PyArg_ParseTuple(args, "O&ss", &PyObjectToWorker, &worker, &remote_function_name, &error_message)) {
+    return NULL;
+  }
+  worker->notify_failure(FailedType::FailedRemoteFunctionImport, std::string(remote_function_name), std::string(error_message));
+  Py_RETURN_NONE;
+}
+
+static PyObject* notify_reusable_variable_import_failure(PyObject* self, PyObject* args) {
+  Worker* worker;
+  const char* reusable_variable_name;
+  const char* error_message;
+  if (!PyArg_ParseTuple(args, "O&ss", &PyObjectToWorker, &worker, &reusable_variable_name, &error_message)) {
+    return NULL;
+  }
+  worker->notify_failure(FailedType::FailedReusableVariableImport, std::string(reusable_variable_name), std::string(error_message));
+  Py_RETURN_NONE;
+}
+
+static PyObject* notify_reinitialize_reusable_variable_failure(PyObject* self, PyObject* args) {
+  Worker* worker;
+  const char* remote_function_name;
+  const char* error_message;
+  if (!PyArg_ParseTuple(args, "O&ss", &PyObjectToWorker, &worker, &remote_function_name, &error_message)) {
+    return NULL;
+  }
+  worker->notify_failure(FailedType::FailedReinitializeReusableVariable, std::string(remote_function_name), std::string(error_message));
   Py_RETURN_NONE;
 }
 
@@ -887,10 +931,12 @@ static PyObject* alias_objectids(PyObject* self, PyObject* args) {
 
 static PyObject* start_worker_service(PyObject* self, PyObject* args) {
   Worker* worker;
-  if (!PyArg_ParseTuple(args, "O&", &PyObjectToWorker, &worker)) {
+  PyObject* is_driver;
+  PyObject* surpress_error_messages;
+  if (!PyArg_ParseTuple(args, "O&OO", &PyObjectToWorker, &worker, &is_driver, &surpress_error_messages)) {
     return NULL;
   }
-  worker->start_worker_service();
+  worker->start_worker_service(PyObject_IsTrue(is_driver), PyObject_IsTrue(surpress_error_messages));
   Py_RETURN_NONE;
 }
 
@@ -917,6 +963,15 @@ static PyObject* scheduler_info(PyObject* self, PyObject* args) {
   set_dict_item_and_transfer_ownership(dict, PyString_FromString("target_objectids"), target_objectid_list);
   set_dict_item_and_transfer_ownership(dict, PyString_FromString("reference_counts"), reference_count_list);
   return dict;
+}
+
+static PyObject* failure_to_dict(const Failure& failure) {
+  PyObject* failure_dict = PyDict_New();
+  set_dict_item_and_transfer_ownership(failure_dict, PyString_FromString("workerid"), PyInt_FromLong(failure.workerid()));
+  set_dict_item_and_transfer_ownership(failure_dict, PyString_FromString("worker_address"), PyString_FromStringAndSize(failure.worker_address().data(), failure.worker_address().size()));
+  set_dict_item_and_transfer_ownership(failure_dict, PyString_FromString("function_name"), PyString_FromStringAndSize(failure.name().data(), failure.name().size()));
+  set_dict_item_and_transfer_ownership(failure_dict, PyString_FromString("error_message"), PyString_FromStringAndSize(failure.error_message().data(), failure.error_message().size()));
+  return failure_dict;
 }
 
 static PyObject* task_info(PyObject* self, PyObject* args) {
@@ -950,10 +1005,27 @@ static PyObject* task_info(PyObject* self, PyObject* args) {
     PyList_SetItem(running_tasks_list, i, info_dict);
   }
 
+  PyObject* failed_remote_function_imports = PyList_New(reply.failed_remote_function_import_size());
+  for (size_t i = 0; i < reply.failed_remote_function_import_size(); ++i) {
+    PyList_SetItem(failed_remote_function_imports, i, failure_to_dict(reply.failed_remote_function_import(i)));
+  }
+
+  PyObject* failed_reusable_variable_imports = PyList_New(reply.failed_reusable_variable_import_size());
+  for (size_t i = 0; i < reply.failed_reusable_variable_import_size(); ++i) {
+    PyList_SetItem(failed_reusable_variable_imports, i, failure_to_dict(reply.failed_reusable_variable_import(i)));
+  }
+
+  PyObject* failed_reinitialize_reusable_variables = PyList_New(reply.failed_reinitialize_reusable_variable_size());
+  for (size_t i = 0; i < reply.failed_reinitialize_reusable_variable_size(); ++i) {
+    PyList_SetItem(failed_reinitialize_reusable_variables, i, failure_to_dict(reply.failed_reinitialize_reusable_variable(i)));
+  }
+
   PyObject* dict = PyDict_New();
   set_dict_item_and_transfer_ownership(dict, PyString_FromString("failed_tasks"), failed_tasks_list);
   set_dict_item_and_transfer_ownership(dict, PyString_FromString("running_tasks"), running_tasks_list);
-  set_dict_item_and_transfer_ownership(dict, PyString_FromString("num_succeeded"), PyInt_FromLong(reply.num_succeeded()));
+  set_dict_item_and_transfer_ownership(dict, PyString_FromString("failed_remote_function_imports"), failed_remote_function_imports);
+  set_dict_item_and_transfer_ownership(dict, PyString_FromString("failed_reusable_variable_imports"), failed_reusable_variable_imports);
+  set_dict_item_and_transfer_ownership(dict, PyString_FromString("failed_reinitialize_reusable_variables"), failed_reinitialize_reusable_variables);
   return dict;
 }
 
@@ -1008,7 +1080,11 @@ static PyMethodDef RayLibMethods[] = {
  { "create_worker", create_worker, METH_VARARGS, "connect to the scheduler and the object store" },
  { "disconnect", disconnect, METH_VARARGS, "disconnect the worker from the scheduler and the object store" },
  { "connected", connected, METH_VARARGS, "check if the worker is connected to the scheduler and the object store" },
- { "register_function", register_function, METH_VARARGS, "register a function with the scheduler" },
+ { "register_remote_function", register_remote_function, METH_VARARGS, "register a function with the scheduler" },
+ { "notify_task_failure", notify_task_failure, METH_VARARGS, "notify the scheduler that a task failed" },
+ { "notify_remote_function_import_failure", notify_remote_function_import_failure, METH_VARARGS, "notify the scheduler that a remote function failed to import" },
+ { "notify_reusable_variable_import_failure", notify_reusable_variable_import_failure, METH_VARARGS, "notify the scheduler that a reusable variable failed to import" },
+ { "notify_reinitialize_reusable_variable_failure", notify_reinitialize_reusable_variable_failure, METH_VARARGS, "notify the scheduler that an attempt to reinitialize a reusable variable failed" },
  { "put_object", put_object, METH_VARARGS, "put a protocol buffer object (given as a capsule) on the local object store" },
  { "get_object", get_object, METH_VARARGS, "get protocol buffer object from the local object store" },
  { "get_objectid", get_objectid, METH_VARARGS, "register a new object reference with the scheduler" },
@@ -1019,8 +1095,8 @@ static PyMethodDef RayLibMethods[] = {
  { "notify_task_completed", notify_task_completed, METH_VARARGS, "notify the scheduler that a task has been completed" },
  { "start_worker_service", start_worker_service, METH_VARARGS, "start the worker service" },
  { "scheduler_info", scheduler_info, METH_VARARGS, "get info about scheduler state" },
- { "task_info", task_info, METH_VARARGS, "get task statuses" },
- { "export_function", export_function, METH_VARARGS, "export function to workers" },
+ { "task_info", task_info, METH_VARARGS, "get information about task statuses and failures" },
+ { "export_remote_function", export_remote_function, METH_VARARGS, "export a remote function to workers" },
  { "export_reusable_variable", export_reusable_variable, METH_VARARGS, "export a reusable variable to the workers" },
  { "dump_computation_graph", dump_computation_graph, METH_VARARGS, "dump the current computation graph to a file" },
  { "set_log_config", set_log_config, METH_VARARGS, "set filename for raylib logging" },

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -9,12 +9,15 @@ extern "C" {
   static PyObject *RayError;
 }
 
-inline WorkerServiceImpl::WorkerServiceImpl(const std::string& worker_address)
-  : worker_address_(worker_address) {
+inline WorkerServiceImpl::WorkerServiceImpl(const std::string& worker_address, bool is_driver, bool surpress_error_messages)
+  : worker_address_(worker_address),
+    is_driver_(is_driver),
+    surpress_error_messages_(surpress_error_messages) {
   RAY_CHECK(send_queue_.connect(worker_address_, false), "error connecting send_queue_");
 }
 
-Status WorkerServiceImpl::ExecuteTask(ServerContext* context, const ExecuteTaskRequest* request, ExecuteTaskReply* reply) {
+Status WorkerServiceImpl::ExecuteTask(ServerContext* context, const ExecuteTaskRequest* request, AckReply* reply) {
+  RAY_CHECK(!is_driver_, "ExecuteTask can only be called on workers.");
   RAY_LOG(RAY_INFO, "invoked task " << request->task().name());
   std::unique_ptr<WorkerMessage> message(new WorkerMessage());
   message->mutable_task()->CopyFrom(request->task());
@@ -26,7 +29,8 @@ Status WorkerServiceImpl::ExecuteTask(ServerContext* context, const ExecuteTaskR
   return Status::OK;
 }
 
-Status WorkerServiceImpl::ImportFunction(ServerContext* context, const ImportFunctionRequest* request, ImportFunctionReply* reply) {
+Status WorkerServiceImpl::ImportRemoteFunction(ServerContext* context, const ImportRemoteFunctionRequest* request, AckReply* reply) {
+  RAY_CHECK(!is_driver_, "ImportRemoteFunction can only be called on workers.");
   std::unique_ptr<WorkerMessage> message(new WorkerMessage());
   message->mutable_function()->CopyFrom(request->function());
   RAY_LOG(RAY_INFO, "importing function");
@@ -39,6 +43,7 @@ Status WorkerServiceImpl::ImportFunction(ServerContext* context, const ImportFun
 }
 
 Status WorkerServiceImpl::ImportReusableVariable(ServerContext* context, const ImportReusableVariableRequest* request, AckReply* reply) {
+  RAY_CHECK(!is_driver_, "ImportReusableVariable can only be called on workers.");
   std::unique_ptr<WorkerMessage> message(new WorkerMessage());
   message->mutable_reusable_variable()->CopyFrom(request->reusable_variable());
   RAY_LOG(RAY_INFO, "importing reusable variable");
@@ -50,9 +55,36 @@ Status WorkerServiceImpl::ImportReusableVariable(ServerContext* context, const I
   return Status::OK;
 }
 
-Status WorkerServiceImpl::Die(ServerContext* context, const DieRequest* request, DieReply* reply) {
+Status WorkerServiceImpl::Die(ServerContext* context, const DieRequest* request, AckReply* reply) {
+  RAY_CHECK(!is_driver_, "Die can only be called on workers.");
   WorkerMessage* message_ptr = NULL;
   RAY_CHECK(send_queue_.send(&message_ptr), "error sending over IPC");
+  return Status::OK;
+}
+
+Status WorkerServiceImpl::PrintErrorMessage(ServerContext* context, const PrintErrorMessageRequest* request, AckReply* reply) {
+  RAY_CHECK(is_driver_, "PrintErrorMessage can only be called on drivers.");
+  if (surpress_error_messages_) {
+    // Do not log error messages in this case. This is just used for the tests.
+    return Status::OK;
+  }
+  const Failure failure = request->failure();
+  WorkerId workerid = failure.workerid();
+  if (failure.type() == FailedType::FailedTask) {
+    // A task threw an exception while executing.
+    std::cout << "Error: Worker " << workerid << " failed to execute function " << failure.name() << ". Failed with error message:\n" << failure.error_message() << std::endl;
+  } else if (failure.type() == FailedType::FailedRemoteFunctionImport) {
+    // An exception was thrown while a remote function was being imported.
+    std::cout << "Error: Worker " << workerid << " failed to import remote function " << failure.name() << ", failed with error message:\n" << failure.error_message() << std::endl;
+  } else if (failure.type() == FailedType::FailedReusableVariableImport) {
+    // An exception was thrown while a reusable variable was being imported.
+    std::cout << "Error: Worker " << workerid << " failed to import reusable variable " << failure.name() << ", failed with error message:\n" << failure.error_message() << std::endl;
+  } else if (failure.type() == FailedType::FailedReinitializeReusableVariable) {
+    // An exception was thrown while a reusable variable was being reinitialized.
+    std::cout << "Error: Worker " << workerid << " failed to reinitialize a reusable variable after running remote function " << failure.name() << ", failed with error message:\n" << failure.error_message() << std::endl;
+  } else {
+    RAY_CHECK(false, "This code should be unreachable.")
+  }
   return Status::OK;
 }
 
@@ -61,6 +93,7 @@ Worker::Worker(const std::string& scheduler_address)
   auto scheduler_channel = grpc::CreateChannel(scheduler_address, grpc::InsecureChannelCredentials());
   scheduler_stub_ = Scheduler::NewStub(scheduler_channel);
 }
+
 
 SubmitTaskReply Worker::submit_task(SubmitTaskRequest* request, int max_retries, int retry_wait_milliseconds) {
   RAY_CHECK(connected_, "Attempted to perform submit_task but failed.");
@@ -312,15 +345,28 @@ void Worker::decrement_reference_count(std::vector<ObjectID> &objectids) {
   }
 }
 
-void Worker::register_function(const std::string& name, size_t num_return_vals) {
+void Worker::register_remote_function(const std::string& name, size_t num_return_vals) {
   RAY_CHECK(connected_, "Attempted to perform register_function but failed.");
   ClientContext context;
-  RegisterFunctionRequest request;
-  request.set_fnname(name);
-  request.set_num_return_vals(num_return_vals);
+  RegisterRemoteFunctionRequest request;
   request.set_workerid(workerid_);
+  request.set_function_name(name);
+  request.set_num_return_vals(num_return_vals);
   AckReply reply;
-  scheduler_stub_->RegisterFunction(&context, request, &reply);
+  scheduler_stub_->RegisterRemoteFunction(&context, request, &reply);
+}
+
+void Worker::notify_failure(FailedType type, const std::string& name, const std::string& error_message) {
+  RAY_CHECK(connected_, "Attempted to perform notify_failure but failed.");
+  ClientContext context;
+  NotifyFailureRequest request;
+  request.mutable_failure()->set_type(type);
+  request.mutable_failure()->set_workerid(workerid_);
+  request.mutable_failure()->set_worker_address(worker_address_);
+  request.mutable_failure()->set_name(name);
+  request.mutable_failure()->set_error_message(error_message);
+  AckReply reply;
+  scheduler_stub_->NotifyFailure(&context, request, &reply);
 }
 
 std::unique_ptr<WorkerMessage> Worker::receive_next_message() {
@@ -329,24 +375,19 @@ std::unique_ptr<WorkerMessage> Worker::receive_next_message() {
   return std::unique_ptr<WorkerMessage>(message_ptr);
 }
 
-void Worker::notify_task_completed(bool task_succeeded, std::string error_message) {
+void Worker::notify_task_completed() {
   RAY_CHECK(connected_, "Attempted to perform notify_task_completed but failed.");
   ClientContext context;
   ReadyForNewTaskRequest request;
   request.set_workerid(workerid_);
-  ReadyForNewTaskRequest::PreviousTaskInfo* previous_task_info = request.mutable_previous_task_info();
-  previous_task_info->set_task_succeeded(task_succeeded);
-  previous_task_info->set_error_message(error_message);
   AckReply reply;
   scheduler_stub_->ReadyForNewTask(&context, request, &reply);
 }
 
 void Worker::disconnect() {
   connected_ = false;
-}
-
-bool Worker::connected() {
-  return connected_;
+  // TODO(rkn): This probably isn't the right way to clean up the thread.
+  worker_server_thread_->detach();
 }
 
 // TODO(rkn): Should we be using pointers or references? And should they be const?
@@ -360,13 +401,14 @@ void Worker::task_info(ClientContext &context, TaskInfoRequest &request, TaskInf
   scheduler_stub_->TaskInfo(&context, request, &reply);
 }
 
-bool Worker::export_function(const std::string& function) {
+bool Worker::export_remote_function(const std::string& function_name, const std::string& function) {
   RAY_CHECK(connected_, "Attempted to export function but failed.");
   ClientContext context;
-  ExportFunctionRequest request;
+  ExportRemoteFunctionRequest request;
+  request.mutable_function()->set_name(function_name);
   request.mutable_function()->set_implementation(function);
-  ExportFunctionReply reply;
-  Status status = scheduler_stub_->ExportFunction(&context, request, &reply);
+  AckReply reply;
+  Status status = scheduler_stub_->ExportRemoteFunction(&context, request, &reply);
   return true;
 }
 
@@ -385,26 +427,32 @@ void Worker::export_reusable_variable(const std::string& name, const std::string
 // queue. This is because the Python interpreter needs to be single threaded
 // (in our case running in the main thread), whereas the WorkerService will
 // run in a separate thread and potentially utilize multiple threads.
-void Worker::start_worker_service() {
+void Worker::start_worker_service(bool is_driver, bool surpress_error_messages) {
   const char* service_addr = worker_address_.c_str();
-  worker_server_thread_ = std::thread([this, service_addr]() {
+  // Launch a new thread for running the worker service. We store this as a
+  // field so that we can clean it up when we disconnect the worker.
+  worker_server_thread_ = std::unique_ptr<std::thread>(new std::thread([this, service_addr, is_driver, surpress_error_messages]() {
     std::string service_address(service_addr);
     std::string::iterator split_point = split_ip_address(service_address);
     std::string port;
     port.assign(split_point, service_address.end());
-    WorkerServiceImpl service(service_address);
+    // Create the worker service.
+    WorkerServiceImpl service(service_address, is_driver, surpress_error_messages);
     ServerBuilder builder;
     builder.AddListeningPort(std::string("0.0.0.0:") + port, grpc::InsecureServerCredentials());
     builder.RegisterService(&service);
     std::unique_ptr<Server> server(builder.BuildAndStart());
     RAY_LOG(RAY_INFO, "worker server listening on " << service_address);
-
-    ClientContext context;
-    ReadyForNewTaskRequest request;
-    request.set_workerid(workerid_);
-    AckReply reply;
-    scheduler_stub_->ReadyForNewTask(&context, request, &reply);
-
+    // If this is part of a worker process (and not a driver process), then tell
+    // the scheduler that it is ready to start receiving tasks.
+    if (!is_driver) {
+      ClientContext context;
+      ReadyForNewTaskRequest request;
+      request.set_workerid(workerid_);
+      AckReply reply;
+      scheduler_stub_->ReadyForNewTask(&context, request, &reply);
+    }
+    // Wait for work and process work, this does not return.
     server->Wait();
-  });
+  }));
 }

--- a/src/worker.h
+++ b/src/worker.h
@@ -25,14 +25,19 @@ using grpc::ClientWriter;
 
 class WorkerServiceImpl final : public WorkerService::Service {
 public:
-  WorkerServiceImpl(const std::string& worker_address);
-  Status ExecuteTask(ServerContext* context, const ExecuteTaskRequest* request, ExecuteTaskReply* reply) override;
-  Status ImportFunction(ServerContext* context, const ImportFunctionRequest* request, ImportFunctionReply* reply) override;
-  Status Die(ServerContext* context, const DieRequest* request, DieReply* reply) override;
+  WorkerServiceImpl(const std::string& worker_address, bool is_driver, bool surpress_error_messages);
+  Status ExecuteTask(ServerContext* context, const ExecuteTaskRequest* request, AckReply* reply) override;
+  Status ImportRemoteFunction(ServerContext* context, const ImportRemoteFunctionRequest* request, AckReply* reply) override;
+  Status Die(ServerContext* context, const DieRequest* request, AckReply* reply) override;
   Status ImportReusableVariable(ServerContext* context, const ImportReusableVariableRequest* request, AckReply* reply) override;
+  Status PrintErrorMessage(ServerContext* context, const PrintErrorMessageRequest* request, AckReply* reply) override;
 private:
   std::string worker_address_;
   MessageQueue<WorkerMessage*> send_queue_;
+  // This is true if the worker service is part of a driver process and false
+  // if it is part of a worker process.
+  bool is_driver_;
+  bool surpress_error_messages_;
 };
 
 class Worker {
@@ -71,27 +76,30 @@ class Worker {
   void increment_reference_count(std::vector<ObjectID> &objectid);
   // decrement the reference count for objectid
   void decrement_reference_count(std::vector<ObjectID> &objectid);
-  // register function with scheduler
-  void register_function(const std::string& name, size_t num_return_vals);
-  // start the worker server which accepts tasks from the scheduler and stores
-  // it in the message queue, which is read by the Python interpreter
-  void start_worker_service();
+  // Notify the scheduler that a remote function has been imported successfully.
+  void register_remote_function(const std::string& name, size_t num_return_vals);
+  // Notify the scheduler that a failure has occurred.
+  void notify_failure(FailedType type, const std::string& name, const std::string& error_message);
+  // Start the worker server which accepts commands from the scheduler. For
+  // workers, these commands are stored in the message queue, which is read by
+  // the Python interpreter. For drivers, these commands are only for printing
+  // error messages.
+  void start_worker_service(bool is_driver, bool surpress_error_messages);
   // wait for next task from the RPC system. If null, it means there are no more tasks and the worker should shut down.
   std::unique_ptr<WorkerMessage> receive_next_message();
   // tell the scheduler that we are done with the current task and request the
-  // next one, if task_succeeded is false, this tells the scheduler that the
-  // task threw an exception
-  void notify_task_completed(bool task_succeeded, std::string error_message);
+  // next one.
+  void notify_task_completed();
   // disconnect the worker
   void disconnect();
   // return connected_
-  bool connected();
+  bool connected() { return connected_; }
   // get info about scheduler state
   void scheduler_info(ClientContext &context, SchedulerInfoRequest &request, SchedulerInfoReply &reply);
   // get task statuses from scheduler
   void task_info(ClientContext &context, TaskInfoRequest &request, TaskInfoReply &reply);
   // export function to workers
-  bool export_function(const std::string& function);
+  bool export_remote_function(const std::string& function_name, const std::string& function);
   // export reusable variable to workers
   void export_reusable_variable(const std::string& name, const std::string& initializer, const std::string& reinitializer);
   // return the worker address
@@ -101,7 +109,7 @@ class Worker {
   bool connected_;
   const size_t CHUNK_SIZE = 8 * 1024;
   std::unique_ptr<Scheduler::Stub> scheduler_stub_;
-  std::thread worker_server_thread_;
+  std::unique_ptr<std::thread> worker_server_thread_;
   MessageQueue<WorkerMessage*> receive_queue_;
   bip::managed_shared_memory segment_;
   WorkerId workerid_;


### PR DESCRIPTION
**Other things in this PR:**

1. We start the WorkerService for drivers (which we were not doing before), which drivers only use to receive commands to print error messages. This is how we print error messages asynchronously in the background.
2. Currently workers do 3 things. They execute tasks, they import remote functions, and they import reusable variables. Currently, we catch exceptions thrown during the execution of a task and we propagate the error to the user. This PR extends it so we also catch exceptions thrown while
    - importing reusable variables
    - importing remote functions
    - as well as reinitializing reusable variables

**To think about.**

1. Think about case where a remote function fails to import and a user calls the remote function.
2. We may need to keep track of which driver exported the remote function or reusable variable, so we know which driver to print the error message to. Right now we push the error message to all drivers.