### PR TITLE
Enable running example apps in cluster mode

### DIFF
--- a/examples/hyperopt/README.md
+++ b/examples/hyperopt/README.md
@@ -64,7 +64,7 @@ def generate_random_params():
 results = []
 for _ in range(100):
   randparams = generate_random_params()
-  results.append((randparams, train_cnn_and_compute_accuracy(randparams, epochs)))
+  results.append((randparams, train_cnn_and_compute_accuracy(randparams, train_images, train_labels, validation_images, validation_labels)))
 ```
 
 Then we can inspect the contents of `results` and see which set of
@@ -105,7 +105,7 @@ computation. Instead, it simply submits a number of tasks to the scheduler.
 result_ids = []
 for _ in range(100):
   params = generate_random_params()
-  results.append((params, train_cnn_and_compute_accuracy.remote(params, epochs)))
+  results.append((params, train_cnn_and_compute_accuracy.remote(params, train_images, train_labels, validation_images, validation_labels)))
 ```
 
 If we wish to wait until the results have all been retrieved, we can retrieve

--- a/examples/hyperopt/hyperopt.py
+++ b/examples/hyperopt/hyperopt.py
@@ -52,7 +52,7 @@ def cnn_setup(x, y, keep_prob, lr, stddev):
 # Define a remote function that takes a set of hyperparameters as well as the
 # data, consructs and trains a network, and returns the validation accuracy.
 @ray.remote([dict, int, np.ndarray, np.ndarray, np.ndarray, np.ndarray], [float])
-def train_cnn_and_compute_accuracy(params, epochs, train_images, train_labels, validation_images, validation_labels):
+def train_cnn_and_compute_accuracy(params, steps, train_images, train_labels, validation_images, validation_labels):
   # Extract the hyperparameters from the params dictionary.
   learning_rate = params["learning_rate"]
   batch_size = params["batch_size"]
@@ -68,7 +68,7 @@ def train_cnn_and_compute_accuracy(params, epochs, train_images, train_labels, v
   with tf.Session() as sess:
     # Initialize the network weights.
     sess.run(tf.initialize_all_variables())
-    for i in range(1, epochs):
+    for i in range(1, steps + 1):
       # Fetch the next batch of data.
       image_batch = get_batch(train_images, i, batch_size)
       label_batch = get_batch(train_labels, i, batch_size)
@@ -82,7 +82,7 @@ def train_cnn_and_compute_accuracy(params, epochs, train_images, train_labels, v
         if train_ac < 0.25:
           # Compute the validation accuracy and return.
           totalacc = accuracy.eval(feed_dict={x: validation_images, y: validation_labels, keep_prob: 1.0})
-          return totalacc
+          return float(totalacc)
     # Training is done, compute the validation accuracy and return.
     totalacc = accuracy.eval(feed_dict={x: validation_images, y: validation_labels, keep_prob: 1.0})
   return float(totalacc)

--- a/examples/lbfgs/driver.py
+++ b/examples/lbfgs/driver.py
@@ -1,5 +1,5 @@
-import os
 import ray
+import argparse
 
 import numpy as np
 import scipy.optimize
@@ -7,8 +7,20 @@ import tensorflow as tf
 
 from tensorflow.examples.tutorials.mnist import input_data
 
+parser = argparse.ArgumentParser(description="Run the L-BFGS example.")
+parser.add_argument("--node-ip-address", default=None, type=str, help="The IP address of this node.")
+parser.add_argument("--scheduler-address", default=None, type=str, help="The address of the scheduler.")
+
 if __name__ == "__main__":
-  ray.init(start_ray_local=True, num_workers=16)
+  args = parser.parse_args()
+
+  # If node_ip_address and scheduler_address are provided, then this command
+  # will connect the driver to the existing scheduler. If not, it will start
+  # a local scheduler and connect to it.
+  ray.init(start_ray_local=(args.node_ip_address is None),
+           node_ip_address=args.node_ip_address,
+           scheduler_address=args.scheduler_address,
+           num_workers=(10 if args.node_ip_address is None else None))
 
   # Define the dimensions of the data and of the model.
   image_dimension = 784

--- a/examples/rl_pong/driver.py
+++ b/examples/rl_pong/driver.py
@@ -4,8 +4,13 @@
 import numpy as np
 import cPickle as pickle
 import ray
+import argparse
 
 import gym
+
+parser = argparse.ArgumentParser(description="Run the Pong example.")
+parser.add_argument("--node-ip-address", default=None, type=str, help="The IP address of this node.")
+parser.add_argument("--scheduler-address", default=None, type=str, help="The address of the scheduler.")
 
 # hyperparameters
 H = 200 # number of hidden layer neurons
@@ -108,7 +113,15 @@ def compute_gradient(model):
   return policy_backward(eph, epx, epdlogp, model), reward_sum
 
 if __name__ == "__main__":
-  ray.init(start_ray_local=True, num_workers=10)
+  args = parser.parse_args()
+
+  # If node_ip_address and scheduler_address are provided, then this command
+  # will connect the driver to the existing scheduler. If not, it will start
+  # a local scheduler and connect to it.
+  ray.init(start_ray_local=(args.node_ip_address is None),
+           node_ip_address=args.node_ip_address,
+           scheduler_address=args.scheduler_address,
+           num_workers=(10 if args.node_ip_address is None else None))
 
   # Run the reinforcement learning
   running_reward = None

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -654,8 +654,8 @@ def init(start_ray_local=False, num_workers=None, num_objstores=None, scheduler_
     # not need to start any processes.
     if (num_workers is not None) or (num_objstores is not None):
       raise Exception("The arguments num_workers and num_objstores must not be provided unless start_ray_local=True.")
-    if node_ip_address is None:
-      raise Exception("When start_ray_local=False, the node_ip_address of the current node must be provided.")
+    if (node_ip_address is None) or (scheduler_address is None):
+      raise Exception("When start_ray_local=False, node_ip_address and scheduler_address must be provided.")
   # Connect this driver to the scheduler and object store. The corresponing call
   # to disconnect will happen in the call to cleanup() when the Python script
   # exits.

--- a/scripts/cluster.py
+++ b/scripts/cluster.py
@@ -162,7 +162,7 @@ class RayCluster(object):
     start_scheduler_command = """
       cd "{}";
       source ../setup-env.sh;
-      python -c "import ray; ray.services.start_scheduler(\\\"{}:10001\\\", local=False)" > start_scheduler.out 2> start_scheduler.err < /dev/null &
+      python -c "import ray; ray.services.start_scheduler(\\\"{}:10001\\\", cleanup=False)" > start_scheduler.out 2> start_scheduler.err < /dev/null &
     """.format(scripts_directory, self.node_private_ip_addresses[0])
     self._run_command_over_ssh(self.node_ip_addresses[0], start_scheduler_command)
 


### PR DESCRIPTION
This allows the example applications to be run with an existing Ray cluster without modification to the script.

To run locally, do

```
python examples/hyperopt/driver.py
```

To attach to an existing cluster, do something like

```
python examples/hyperopt/driver.py --node-ip-address=12.456.78.9 --scheduler-address=12.456.78.9:10001
```
