### PR TITLE
Improve error message for serialization of custom objects

### DIFF
--- a/src/raylib.cc
+++ b/src/raylib.cc
@@ -343,7 +343,10 @@ int serialize(PyObject* worker_capsule, PyObject* val, Obj* obj, std::vector<Obj
             if (PyObject_IsInstance(*item, (PyObject*) &PyObjectIDType)) {
               objectid = ((PyObjectID*) (*item))->id;
             } else {
-              PyErr_SetString(PyExc_TypeError, "must be an object reference"); // TODO: improve error message
+              std::stringstream ss;
+              ss << "data type of " << PyString_AS_STRING(PyObject_Repr(*item))
+                 << " not recognized";
+              PyErr_SetString(PyExc_TypeError, ss.str().c_str());
               return -1;
             }
             data->add_objectid_data(objectid);


### PR DESCRIPTION
This PR contains a few small fixes:

- numbuf now throws a Python error if a python object is contained in a numpy array instead of exiting the process with an assertion. The error is then caught in ray and the protobuf serializer is used.

- if the protobuf serializer detects an object in a numpy array that is not an object reference, the actual object is now printed in the error messages to make it easier to track the object down (this is a temporary fix until we can serialize custom python objects within python collections)

- the numbuf build directory is gitignored