### PR TITLE
Better .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# The build directory should clearly not be checked in
+# The build output should clearly not be checked in
 /build
+/lib/python/ray/objstore
+/lib/python/ray/scheduler
 
 # Python byte code files
 *.pyc
@@ -60,3 +62,9 @@
 
 # Ray cluster configuration
 scripts/nodes.txt
+
+# OS X folder attributes
+.DS_Store
+
+# Datasets from examples
+**/MNIST_data/


### PR DESCRIPTION
Cleaning up .gitignore to avoid checking in build artifacts, example datasets, OS X system files.

Fix for this:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.DS_Store
	examples/lbfgs/MNIST_data/
	lib/python/ray/objstore
	lib/python/ray/scheduler
```