### PR TITLE
Changing hard coded ports for objstore and workers to choose unused ports

### DIFF
--- a/protos/ray.proto
+++ b/protos/ray.proto
@@ -65,15 +65,15 @@ message AckReply {
 
 message RegisterWorkerRequest {
   string node_ip_address = 1; // The IP address of the node the worker is running on.
-  string objstore_address = 2; // The address of the object store the worker should connect to. If omitted, this will be assigned by the scheduler.
-  bool is_driver = 3; // True if the worker is a driver, and false otherwise.
+  string worker_address = 2; // The address of the worker.
+  string objstore_address = 3; // The address of the object store the worker should connect to. If omitted, this will be assigned by the scheduler.
+  bool is_driver = 4; // True if the worker is a driver, and false otherwise.
 }
 
 message RegisterWorkerReply {
   uint64 workerid = 1; // Worker ID assigned by the scheduler
   uint64 objstoreid = 2; // The Object store ID of the worker's local object store
-  string worker_address = 3; // IP address of the worker being registered
-  string objstore_address = 4; // IP address of the object store the worker should connect to
+  string objstore_address = 3; // IP address of the object store the worker should connect to
 }
 
 message RegisterObjStoreRequest {

--- a/protos/ray.proto
+++ b/protos/ray.proto
@@ -165,6 +165,7 @@ message SchedulerInfoReply {
   repeated uint64 target_objectid = 4; // The target_objectids_ data structure
   repeated uint64 reference_count = 5; // The reference_counts_ data structure
   CompGraph computation_graph = 6; // The computation graph constructed so far
+  repeated ObjstoreData objstore = 7; // Information about the object stores
 }
 
 // Object stores

--- a/protos/types.proto
+++ b/protos/types.proto
@@ -66,6 +66,11 @@ message Failure {
   string error_message = 5; // The error message from the failure.
 }
 
+message ObjstoreData {
+  uint64 objstoreid = 1; // The ID of the object store.
+  string address = 2; // The address of the object store.
+}
+
 // Union of possible object types
 message Obj {
   String string_data = 1;

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -117,7 +117,7 @@ enum SegmentStatusType {UNOPENED = 0, OPENED = 1, CLOSED = 2};
 
 class MemorySegmentPool {
 public:
-  MemorySegmentPool(ObjStoreId objstoreid, bool create); // can be used in two modes: create mode and open mode (see above)
+  MemorySegmentPool(ObjStoreId objstoreid, std::string& objstore_address, bool create); // can be used in two modes: create mode and open mode (see above)
   ~MemorySegmentPool();
   ObjHandle allocate(size_t nbytes); // allocate memory, potentially creating a new segment (only run on object store)
   void deallocate(ObjHandle pointer); // deallocate object, potentially deallocating a new segment (only run on object store)
@@ -131,6 +131,10 @@ private:
   void close_segment(SegmentId segmentid); // close a segment
   bool create_mode_; // true in the object stores, false on the workers
   ObjStoreId objstoreid_; // the identity of the associated object store
+  // The address of the object store.
+  std::string objstore_address_;
+  // The port of the object store. This is used to help avoid name collisions.
+  std::string objstore_port_;
   size_t page_size_ = bip::mapped_region::get_page_size();
   std::vector<std::pair<std::unique_ptr<bip::managed_shared_memory>, SegmentStatusType> > segments_;
 };

--- a/src/objstore.cc
+++ b/src/objstore.cc
@@ -39,16 +39,28 @@ void ObjStoreService::get_data_from(ObjectID objectid, ObjStore::Stub& stub) {
   RAY_LOG(RAY_DEBUG, "finished streaming data, objectid was " << objectid << " and size was " << num_bytes);
 }
 
-ObjStoreService::ObjStoreService(const std::string& objstore_address, std::shared_ptr<Channel> scheduler_channel)
-  : scheduler_stub_(Scheduler::NewStub(scheduler_channel)), objstore_address_(objstore_address) {
-  RAY_CHECK(recv_queue_.connect(std::string("queue:") + objstore_address + std::string(":obj"), true), "error connecting recv_queue_");
+ObjStoreService::ObjStoreService(const std::string& scheduler_address)
+    : scheduler_address_(scheduler_address) {
+}
+
+void ObjStoreService::register_objstore() {
+  RAY_CHECK(!objstore_address_.empty(), "The object store address must be set before register_objstore is called.");
+  // Create the scheduler stub.
+  auto scheduler_channel = grpc::CreateChannel(scheduler_address_, grpc::InsecureChannelCredentials());
+  scheduler_stub_ = Scheduler::NewStub(scheduler_channel);
+
+  // Create message queue to receive requests from workers.
+  std::string recv_queue_name = std::string("queue:") + objstore_address_ + std::string(":obj");
+  RAY_LOG(RAY_INFO, "Object store creating queue with name " << recv_queue_name << " to receive requests from workers.");
+  RAY_CHECK(recv_queue_.connect(recv_queue_name, true), "error connecting recv_queue_");
+  // Register the objecet store with the scheduler.
   ClientContext context;
   RegisterObjStoreRequest request;
-  request.set_objstore_address(objstore_address);
+  request.set_objstore_address(objstore_address_);
   RegisterObjStoreReply reply;
   scheduler_stub_->RegisterObjStore(&context, request, &reply);
   objstoreid_ = reply.objstoreid();
-  segmentpool_ = std::make_shared<MemorySegmentPool>(objstoreid_, true);
+  segmentpool_ = std::make_shared<MemorySegmentPool>(objstoreid_, objstore_address_, true);
 }
 
 // this method needs to be protected by a objstores_lock_
@@ -319,20 +331,41 @@ void ObjStoreService::start_objstore_service() {
   });
 }
 
-void start_objstore(const char* scheduler_addr, const char* objstore_addr) {
-  auto scheduler_channel = grpc::CreateChannel(scheduler_addr, grpc::InsecureChannelCredentials());
-  RAY_LOG(RAY_INFO, "object store " << objstore_addr << " connected to scheduler " << scheduler_addr);
-  std::string objstore_address(objstore_addr);
-  ObjStoreService service(objstore_address, scheduler_channel);
-  service.start_objstore_service();
-  std::string::iterator split_point = split_ip_address(objstore_address);
-  std::string port;
-  port.assign(split_point, objstore_address.end());
+void set_logfile(const char* log_file_prefix, const std::string& node_ip_address, int port) {
+  if (log_file_prefix) {
+    std::string log_file_name = std::string(log_file_prefix) + "objstore-" + node_ip_address + "-" + std::to_string(port) + ".log";
+    create_log_dir_or_die(log_file_name.c_str());
+    global_ray_config.log_to_file = true;
+    global_ray_config.logfile.open(log_file_name);
+  } else {
+    std::cout << "object store: writing logs to stdout; you can change this by passing --log-file-prefix <fileprefix> to ./objstore" << std::endl;
+    global_ray_config.log_to_file = false;
+  }
+}
+
+void start_objstore(const std::string& scheduler_address, const std::string& node_ip_address, const char* log_file_prefix) {
+  // Initialize the object store.
+  ObjStoreService service(scheduler_address);
+  int port;
   ServerBuilder builder;
-  builder.AddListeningPort(std::string("0.0.0.0:") + port, grpc::InsecureServerCredentials());
+  // Get GRPC to assign an unused port.
+  builder.AddListeningPort(std::string("0.0.0.0:0"), grpc::InsecureServerCredentials(), &port);
   builder.RegisterService(&service);
   std::unique_ptr<Server> server(builder.BuildAndStart());
-
+  if (server == nullptr) {
+    RAY_CHECK(false, "Failed to create the object store server.")
+  }
+  // Set the object store address.
+  service.set_objstore_address(node_ip_address + ":" + std::to_string(port));
+  // Set the logfile.
+  set_logfile(log_file_prefix, node_ip_address, port);
+  // Register the object store with the scheduler.
+  service.register_objstore();
+  // Launch a thread to process incoming messages in the message queue from
+  // the workers.
+  service.start_objstore_service();
+  // Process incoming GRPC calls. These may come from the schedeler or from
+  // other object stores. This method does not return.
   server->Wait();
 }
 
@@ -341,20 +374,12 @@ RayConfig global_ray_config;
 int main(int argc, char** argv) {
   RAY_CHECK_GE(argc, 3, "object store: expected at least two arguments (scheduler ip address and object store ip address)");
 
+  const char* log_file_prefix = nullptr;
   if (argc > 3) {
-    const char* log_file_name = get_cmd_option(argv, argv + argc, "--log-file-name");
-    if (log_file_name) {
-      std::cout << "object store: writing to log file " << log_file_name << std::endl;
-      create_log_dir_or_die(log_file_name);
-      global_ray_config.log_to_file = true;
-      global_ray_config.logfile.open(log_file_name);
-    } else {
-      std::cout << "object store: writing logs to stdout; you can change this by passing --log-file-name <filename> to ./scheduler" << std::endl;
-      global_ray_config.log_to_file = false;
-    }
+    log_file_prefix = get_cmd_option(argv, argv + argc, "--log-file-prefix");
   }
 
-  start_objstore(argv[1], argv[2]);
+  start_objstore(argv[1], argv[2], log_file_prefix);
 
   return 0;
 }

--- a/src/objstore.h
+++ b/src/objstore.h
@@ -37,7 +37,12 @@ enum MemoryStatusType {READY = 0, NOT_READY = 1, DEALLOCATED = 2, NOT_PRESENT = 
 
 class ObjStoreService final : public ObjStore::Service {
 public:
-  ObjStoreService(const std::string& objstore_address, std::shared_ptr<Channel> scheduler_channel);
+  ObjStoreService(const std::string& scheduler_address);
+  // Create the scheduler stub, register the object store with the scheduler,
+  // and create a message queue for workers to connect to.
+  void register_objstore();
+  // Set the object store address.
+  void set_objstore_address(const std::string& objstore_address) { objstore_address_ = objstore_address; }
 
   Status StartDelivery(ServerContext* context, const StartDeliveryRequest* request, AckReply* reply) override;
   Status StreamObjTo(ServerContext* context, const StreamObjToRequest* request, ServerWriter<ObjChunk>* writer) override;
@@ -57,6 +62,7 @@ private:
   void object_ready(ObjectID objectid, size_t metadata_offset);
 
   static const size_t CHUNK_SIZE;
+  std::string scheduler_address_;
   std::string objstore_address_;
   ObjStoreId objstoreid_; // id of this objectstore in the scheduler object store table
   std::shared_ptr<MemorySegmentPool> segmentpool_;

--- a/src/raylib.cc
+++ b/src/raylib.cc
@@ -665,12 +665,12 @@ static PyObject* create_worker(PyObject* self, PyObject* args) {
   // The object store address can be the empty string, in which case the
   // scheduler will choose the object store address.
   const char* objstore_address;
-  PyObject* is_driver_obj;
-  if (!PyArg_ParseTuple(args, "sssO", &node_ip_address, &scheduler_address, &objstore_address, &is_driver_obj)) {
+  Mode mode;
+  if (!PyArg_ParseTuple(args, "sssi", &node_ip_address, &scheduler_address, &objstore_address, &mode)) {
     return NULL;
   }
-  bool is_driver = PyObject_IsTrue(is_driver_obj);
-  Worker* worker = new Worker(std::string(scheduler_address));
+  bool is_driver = (mode != Mode::WORKER_MODE);
+  Worker* worker = new Worker(std::string(node_ip_address), std::string(scheduler_address), mode);
   worker->register_worker(std::string(node_ip_address), std::string(objstore_address), is_driver);
 
   PyObject* t = PyTuple_New(2);
@@ -800,12 +800,12 @@ static PyObject* submit_task(PyObject* self, PyObject* args) {
   return list;
 }
 
-static PyObject* notify_task_completed(PyObject* self, PyObject* args) {
+static PyObject* ready_for_new_task(PyObject* self, PyObject* args) {
   Worker* worker;
   if (!PyArg_ParseTuple(args, "O&", &PyObjectToWorker, &worker)) {
     return NULL;
   }
-  worker->notify_task_completed();
+  worker->ready_for_new_task();
   Py_RETURN_NONE;
 }
 
@@ -1059,7 +1059,7 @@ static PyMethodDef RayLibMethods[] = {
  { "alias_objectids", alias_objectids, METH_VARARGS, "make two objectids refer to the same object" },
  { "wait_for_next_message", wait_for_next_message, METH_VARARGS, "get next message from scheduler (blocking)" },
  { "submit_task", submit_task, METH_VARARGS, "call a remote function" },
- { "notify_task_completed", notify_task_completed, METH_VARARGS, "notify the scheduler that a task has been completed" },
+ { "ready_for_new_task", ready_for_new_task, METH_VARARGS, "notify the scheduler that a task has been completed" },
  { "start_worker_service", start_worker_service, METH_VARARGS, "start the worker service" },
  { "scheduler_info", scheduler_info, METH_VARARGS, "get info about scheduler state" },
  { "task_info", task_info, METH_VARARGS, "get information about task statuses and failures" },

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -716,27 +716,40 @@ void SchedulerService::get_info(const SchedulerInfoRequest& request, SchedulerIn
   auto avail_workers = GET(avail_workers_);
   auto task_queue = GET(task_queue_);
   auto reference_counts = GET(reference_counts_);
+  auto objstores = GET(objstores_);
   auto target_objectids = GET(target_objectids_);
   auto function_table = reply->mutable_function_table();
+  // Return info about the reference counts.
   for (int i = 0; i < reference_counts->size(); ++i) {
     reply->add_reference_count((*reference_counts)[i]);
   }
+  // Return info about the target objectids.
   for (int i = 0; i < target_objectids->size(); ++i) {
     reply->add_target_objectid((*target_objectids)[i]);
   }
+  // Return info about the function table.
   for (const auto& entry : *fntable) {
     (*function_table)[entry.first].set_num_return_vals(entry.second.num_return_vals());
     for (const WorkerId& worker : entry.second.workers()) {
       (*function_table)[entry.first].add_workerid(worker);
     }
   }
+  // Return info about the task queue.
   for (const auto& entry : *task_queue) {
     reply->add_operationid(entry);
   }
+  // Return info about the available workers.
   for (const WorkerId& entry : *avail_workers) {
     reply->add_avail_worker(entry);
   }
+  // Return info about the computation graph.
   computation_graph->to_protobuf(reply->mutable_computation_graph());
+  // Return info about the object stores.
+  for (int i = 0; i < objstores->size(); ++i) {
+    ObjstoreData* objstore_data = reply->add_objstore();
+    objstore_data->set_objstoreid(i);
+    objstore_data->set_address((*objstores)[i].address);
+  }
 }
 
 // pick_objstore must be called with a canonical_objectid

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -215,6 +215,7 @@ Status SchedulerService::RegisterObjStore(ServerContext* context, const Register
 }
 
 Status SchedulerService::RegisterWorker(ServerContext* context, const RegisterWorkerRequest* request, RegisterWorkerReply* reply) {
+  std::string worker_address = request->worker_address();
   std::string objstore_address = request->objstore_address();
   std::string node_ip_address = request->node_ip_address();
   bool is_driver = request->is_driver();
@@ -250,19 +251,11 @@ Status SchedulerService::RegisterWorker(ServerContext* context, const RegisterWo
   } else {
     RAY_CHECK_NEQ(objstoreid, std::numeric_limits<size_t>::max(), "Object store with address " << objstore_address << " not yet registered.");
   }
-  // Populate the worker information and generate a worker address.
+  // Populate the worker information.
   WorkerId workerid;
-  std::string worker_address;
   {
     auto workers = GET(workers_);
     workerid = workers->size();
-    // Generate a random port number. This is currently a hack to avoid reusing
-    // port numbers when we run the tests.
-    std::random_device rd;
-    std::mt19937 rng(rd());
-    std::uniform_int_distribution<int> uni(0, 10000);
-    int port_number = 40000 + uni(rng);
-    worker_address = node_ip_address + ":" + std::to_string(port_number);
     workers->push_back(WorkerHandle());
     auto channel = grpc::CreateChannel(worker_address, grpc::InsecureChannelCredentials());
     (*workers)[workerid].channel = channel;
@@ -279,7 +272,6 @@ Status SchedulerService::RegisterWorker(ServerContext* context, const RegisterWo
   RAY_LOG(RAY_INFO, "Finished registering worker with workerid " << workerid << ", worker address " << worker_address << " on node with IP address " << node_ip_address << ", is_driver = " << is_driver << ", assigned to object store with id " << objstoreid << " and address " << objstore_address);
   reply->set_workerid(workerid);
   reply->set_objstoreid(objstoreid);
-  reply->set_worker_address(worker_address);
   reply->set_objstore_address(objstore_address);
   schedule();
   return Status::OK;
@@ -1064,6 +1056,9 @@ void start_scheduler_service(const char* service_addr, SchedulingAlgorithmType s
   builder.AddListeningPort(std::string("0.0.0.0:") + port, grpc::InsecureServerCredentials());
   builder.RegisterService(&service);
   std::unique_ptr<Server> server(builder.BuildAndStart());
+  if (server == nullptr) {
+    RAY_CHECK(false, "Failed to create the scheduler server.")
+  }
   server->Wait();
 }
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -79,15 +79,16 @@ class SerializationTest(unittest.TestCase):
 
 class ObjStoreTest(unittest.TestCase):
 
+  """
   # Test setting up object stores, transfering data between them and retrieving data to a client
   def testObjStore(self):
     scheduler_address, objstore_addresses = ray.services.start_ray_local(num_objstores=2, num_workers=0, worker_path=None)
     w1 = ray.worker.Worker()
     w2 = ray.worker.Worker()
     node_ip_address = "127.0.0.1"
-    ray.connect(node_ip_address, scheduler_address, objstore_addresses[0], is_driver=True, mode=ray.SCRIPT_MODE, worker=w1)
+    ray.connect(node_ip_address, scheduler_address, objstore_addresses[0], mode=ray.SCRIPT_MODE, worker=w1)
     ray.reusables._cached_reusables = [] # This is a hack to make the test run.
-    ray.connect(node_ip_address, scheduler_address, objstore_addresses[1], is_driver=True, mode=ray.SCRIPT_MODE, worker=w2)
+    ray.connect(node_ip_address, scheduler_address, objstore_addresses[1], mode=ray.SCRIPT_MODE, worker=w2)
 
     # putting and getting an object shouldn't change it
     for data in ["h", "h" * 10000, 0, 0.0]:
@@ -142,6 +143,7 @@ class ObjStoreTest(unittest.TestCase):
     ray.disconnect(worker=w1)
     ray.disconnect(worker=w2)
     ray.worker.cleanup()
+  """
 
 class WorkerTest(unittest.TestCase):
 

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -79,33 +79,51 @@ class SerializationTest(unittest.TestCase):
 
 class ObjStoreTest(unittest.TestCase):
 
-  """
   # Test setting up object stores, transfering data between them and retrieving data to a client
   def testObjStore(self):
-    scheduler_address, objstore_addresses = ray.services.start_ray_local(num_objstores=2, num_workers=0, worker_path=None)
+    node_ip_address = "127.0.0.1"
+    scheduler_address = ray.services.start_ray_local(num_objstores=2, num_workers=0, worker_path=None)
+    ray.connect(node_ip_address, scheduler_address, mode=ray.SCRIPT_MODE)
+    objstore_addresses = [objstore_info["address"] for objstore_info in ray.scheduler_info()["objstores"]]
     w1 = ray.worker.Worker()
     w2 = ray.worker.Worker()
-    node_ip_address = "127.0.0.1"
-    ray.connect(node_ip_address, scheduler_address, objstore_addresses[0], mode=ray.SCRIPT_MODE, worker=w1)
     ray.reusables._cached_reusables = [] # This is a hack to make the test run.
-    ray.connect(node_ip_address, scheduler_address, objstore_addresses[1], mode=ray.SCRIPT_MODE, worker=w2)
+    ray.connect(node_ip_address, scheduler_address, objstore_address=objstore_addresses[0], mode=ray.SCRIPT_MODE, worker=w1)
+    ray.reusables._cached_reusables = [] # This is a hack to make the test run.
+    ray.connect(node_ip_address, scheduler_address, objstore_address=objstore_addresses[1], mode=ray.SCRIPT_MODE, worker=w2)
 
     # putting and getting an object shouldn't change it
-    for data in ["h", "h" * 10000, 0, 0.0]:
+    for data in RAY_TEST_OBJECTS:
       objectid = ray.put(data, w1)
       result = ray.get(objectid, w1)
       self.assertEqual(result, data)
 
     # putting an object, shipping it to another worker, and getting it shouldn't change it
-    for data in ["h", "h" * 10000, 0, 0.0, [1, 2, 3, "a", (1, 2)], ("a", ("b", 3))]:
+    for data in RAY_TEST_OBJECTS:
       objectid = ray.put(data, w1)
       result = ray.get(objectid, w2)
       self.assertEqual(result, data)
 
+    # putting an object, shipping it to another worker, and getting it shouldn't change it
+    for data in RAY_TEST_OBJECTS:
+      objectid = ray.put(data, w2)
+      result = ray.get(objectid, w1)
+      self.assertEqual(result, data)
+
+    ARRAY_TEST_OBJECTS = [np.zeros([10, 20]), np.random.normal(size=[45, 25]),
+                          ("a", np.random.normal(size=[10, 10])),
+                          ["a", np.random.normal(size=[10, 10])]]
+
     # putting an array, shipping it to another worker, and getting it shouldn't change it
-    for data in [np.zeros([10, 20]), np.random.normal(size=[45, 25])]:
+    for data in ARRAY_TEST_OBJECTS:
       objectid = ray.put(data, w1)
       result = ray.get(objectid, w2)
+      assert_equal(result, data)
+
+    # putting an array, shipping it to another worker, and getting it shouldn't change it
+    for data in ARRAY_TEST_OBJECTS:
+      objectid = ray.put(data, w2)
+      result = ray.get(objectid, w1)
       assert_equal(result, data)
 
     # This test fails. See https://github.com/amplab/ray/issues/159.
@@ -116,20 +134,6 @@ class ObjStoreTest(unittest.TestCase):
     #   result = worker.get(objectid, w2)
     #   result = worker.get(objectid, w2)
     #   assert_equal(result, data)
-
-    # shipping a numpy array inside something else should be fine
-    data = ("a", np.random.normal(size=[10, 10]))
-    objectid = ray.put(data, w1)
-    result = ray.get(objectid, w2)
-    self.assertEqual(data[0], result[0])
-    assert_equal(data[1], result[1])
-
-    # shipping a numpy array inside something else should be fine
-    data = ["a", np.random.normal(size=[10, 10])]
-    objectid = ray.put(data, w1)
-    result = ray.get(objectid, w2)
-    self.assertEqual(data[0], result[0])
-    assert_equal(data[1], result[1])
 
     # Getting a buffer after modifying it before it finishes should return updated buffer
     objectid = ray.libraylib.get_objectid(w1.handle)
@@ -143,7 +147,6 @@ class ObjStoreTest(unittest.TestCase):
     ray.disconnect(worker=w1)
     ray.disconnect(worker=w2)
     ray.worker.cleanup()
-  """
 
 class WorkerTest(unittest.TestCase):
 


### PR DESCRIPTION
This PR changes the way we assign ports.

- Worker ports are no longer assigned by the scheduler. They are chosen by GRPC when GRPC starts the worker service (in `start_worker_service`).
- Object store ports are no longer passed in as command line arguments. They are chosen by GRPC when GRPC starts the object store service.
- The scheduler port is passed in via the command line, and is generated randomly beforehand.

**To think about before merging:**

- We had to comment out a test because we no longer have easy access to the object store addresses. Think about how to get around this. For instance, connecting based on objectstore id or something.
- We still see failures on Travis, and running `runtest.py` in some number of terminals (e.g., 3) at the same time causes similar failures.