### PR TITLE
Properly shutdown worker service thread

### DIFF
--- a/src/worker.h
+++ b/src/worker.h
@@ -114,6 +114,7 @@ class Worker {
   const size_t CHUNK_SIZE = 8 * 1024;
   std::unique_ptr<Scheduler::Stub> scheduler_stub_;
   std::unique_ptr<std::thread> worker_server_thread_;
+  Server* server_ptr_;
   MessageQueue<WorkerMessage*> receive_queue_;
   bip::managed_shared_memory segment_;
   WorkerId workerid_;


### PR DESCRIPTION
This PR also changes things so that no worker service is started when running Ray in PYTHON_MODE.