### PR TITLE
[WIP] Error polling without WorkerService on driver

### DIFF
--- a/include/ray/logging.h
+++ b/include/ray/logging.h
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <fstream>
 
+#include <grpc++/grpc++.h>
+
 struct RayConfig {
   bool log_to_file = false;
   std::ofstream logfile;
@@ -54,3 +56,9 @@ extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 #define RAY_CHECK_LT(var1, var2, message) RAY_CHECK((var1) < (var2), message)
 #define RAY_CHECK_GE(var1, var2, message) RAY_CHECK((var1) >= (var2), message)
 #define RAY_CHECK_GT(var1, var2, message) RAY_CHECK((var1) > (var2), message)
+
+#define RAY_CHECK_GRPC(expr) \
+  do { \
+    grpc::Status _s = (expr); \
+    RAY_CHECK(_s.ok(), "grpc call failed with message " << _s.error_message()); \
+  } while (0);

--- a/src/objstore.cc
+++ b/src/objstore.cc
@@ -31,7 +31,7 @@ void ObjStoreService::get_data_from(ObjectID objectid, ObjStore::Stub& stub) {
     data += chunk.data().size();
     num_bytes += chunk.data().size();
   } while (reader->Read(&chunk));
-  Status status = reader->Finish(); // Right now we don't use the status.
+  RAY_CHECK_GRPC(reader->Finish());
 
   // finalize object
   RAY_CHECK_EQ(num_bytes, total_size, "Streamed objectid " << objectid << ", but num_bytes != total_size");
@@ -58,7 +58,7 @@ void ObjStoreService::register_objstore() {
   RegisterObjStoreRequest request;
   request.set_objstore_address(objstore_address_);
   RegisterObjStoreReply reply;
-  scheduler_stub_->RegisterObjStore(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->RegisterObjStore(&context, request, &reply));
   objstoreid_ = reply.objstoreid();
   segmentpool_ = std::make_shared<MemorySegmentPool>(objstoreid_, objstore_address_, true);
 }
@@ -321,7 +321,7 @@ void ObjStoreService::object_ready(ObjectID objectid, size_t metadata_offset) {
   objready_request.set_objectid(objectid);
   objready_request.set_objstoreid(objstoreid_);
   AckReply objready_reply;
-  scheduler_stub_->ObjReady(&objready_context, objready_request, &objready_reply);
+  RAY_CHECK_GRPC(scheduler_stub_->ObjReady(&objready_context, objready_request, &objready_reply));
 }
 
 void ObjStoreService::start_objstore_service() {

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -314,6 +314,7 @@ Status SchedulerService::NotifyFailure(ServerContext* context, const NotifyFailu
   } else {
     RAY_CHECK(false, "This code should be unreachable.")
   }
+  /*
   // Print the failure on the relevant driver. TODO(rkn): At the moment, this
   // prints the failure on all of the drivers. It should probably only print it
   // on the driver that caused the problem.
@@ -332,6 +333,7 @@ Status SchedulerService::NotifyFailure(ServerContext* context, const NotifyFailu
       }
     }
   }
+  */
   return Status::OK;
 }
 

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -328,7 +328,7 @@ Status SchedulerService::NotifyFailure(ServerContext* context, const NotifyFailu
         PrintErrorMessageRequest print_request;
         print_request.mutable_failure()->CopyFrom(request->failure());
         AckReply print_reply;
-        Status status = worker->worker_stub->PrintErrorMessage(&client_context, print_request, &print_reply);
+        RAY_CHECK_GRPC(worker->worker_stub->PrintErrorMessage(&client_context, print_request, &print_reply));
       }
     }
   }
@@ -500,7 +500,7 @@ Status SchedulerService::KillWorkers(ServerContext* context, const KillWorkersRe
       DieRequest die_request;
       AckReply die_reply;
       // TODO: Fault handling... what if a worker refuses to die? We just assume it dies here.
-      idle_worker->worker_stub->Die(&client_context, die_request, &die_reply);
+      RAY_CHECK_GRPC(idle_worker->worker_stub->Die(&client_context, die_request, &die_reply));
       idle_worker->worker_stub.reset();
     }
     avail_workers->clear();
@@ -580,7 +580,7 @@ void SchedulerService::deliver_object_async(ObjectID canonical_objectid, ObjStor
   request.set_objectid(canonical_objectid);
   auto objstores = GET(objstores_);
   request.set_objstore_address((*objstores)[from].address);
-  (*objstores)[to].objstore_stub->StartDelivery(&context, request, &reply);
+  RAY_CHECK_GRPC((*objstores)[to].objstore_stub->StartDelivery(&context, request, &reply));
 }
 
 void SchedulerService::schedule() {
@@ -622,7 +622,7 @@ void SchedulerService::assign_task(OperationId operationid, WorkerId workerid, c
     auto workers = GET(workers_);
     (*workers)[workerid].current_task = operationid;
     request.mutable_task()->CopyFrom(task); // TODO(rkn): Is ownership handled properly here?
-    Status status = (*workers)[workerid].worker_stub->ExecuteTask(&context, request, &reply);
+    RAY_CHECK_GRPC((*workers)[workerid].worker_stub->ExecuteTask(&context, request, &reply));
   }
 }
 
@@ -935,7 +935,7 @@ bool SchedulerService::attempt_notify_alias(ObjStoreId objstoreid, ObjectID alia
   NotifyAliasRequest request;
   request.set_alias_objectid(alias_objectid);
   request.set_canonical_objectid(canonical_objectid);
-  (*GET(objstores_))[objstoreid].objstore_stub->NotifyAlias(&context, request, &reply);
+  RAY_CHECK_GRPC((*GET(objstores_))[objstoreid].objstore_stub->NotifyAlias(&context, request, &reply));
   return true;
 }
 
@@ -1035,7 +1035,7 @@ void SchedulerService::export_function_to_worker(WorkerId workerid, int function
   ImportRemoteFunctionRequest import_request;
   import_request.mutable_function()->CopyFrom(*(*exported_functions)[function_index].get());
   AckReply import_reply;
-  (*workers)[workerid].worker_stub->ImportRemoteFunction(&import_context, import_request, &import_reply);
+  RAY_CHECK_GRPC((*workers)[workerid].worker_stub->ImportRemoteFunction(&import_context, import_request, &import_reply));
 }
 
 void SchedulerService::export_reusable_variable_to_worker(WorkerId workerid, int reusable_variable_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<ReusableVar> > > &exported_reusable_variables) {
@@ -1044,7 +1044,7 @@ void SchedulerService::export_reusable_variable_to_worker(WorkerId workerid, int
   ImportReusableVariableRequest import_request;
   import_request.mutable_reusable_variable()->CopyFrom(*(*exported_reusable_variables)[reusable_variable_index].get());
   AckReply import_reply;
-  (*workers)[workerid].worker_stub->ImportReusableVariable(&import_context, import_request, &import_reply);
+  RAY_CHECK_GRPC((*workers)[workerid].worker_stub->ImportReusableVariable(&import_context, import_request, &import_reply));
 }
 
 void SchedulerService::export_all_functions_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_functions) {

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -314,26 +314,6 @@ Status SchedulerService::NotifyFailure(ServerContext* context, const NotifyFailu
   } else {
     RAY_CHECK(false, "This code should be unreachable.")
   }
-  /*
-  // Print the failure on the relevant driver. TODO(rkn): At the moment, this
-  // prints the failure on all of the drivers. It should probably only print it
-  // on the driver that caused the problem.
-  auto workers = GET(workers_);
-  for (size_t i = 0; i < workers->size(); ++i) {
-    WorkerHandle* worker = &(*workers)[i];
-    // Check if the worker is still connected.
-    if (worker->worker_stub) {
-      // Check if this is a driver.
-      if (worker->current_task == ROOT_OPERATION) {
-        ClientContext client_context;
-        PrintErrorMessageRequest print_request;
-        print_request.mutable_failure()->CopyFrom(request->failure());
-        AckReply print_reply;
-        RAY_CHECK_GRPC(worker->worker_stub->PrintErrorMessage(&client_context, print_request, &print_reply));
-      }
-    }
-  }
-  */
   return Status::OK;
 }
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -403,9 +403,9 @@ void Worker::disconnect() {
   if (mode_ == Mode::WORKER_MODE) {
     // Shut down the worker service. This will cause the call to server->Wait() to
     // return.
-    server_ptr_->Shutdown();
+    // server_ptr_->Shutdown();
     // Wait for the thread that launched the worker service to return.
-    worker_server_thread_.join();
+    // worker_server_thread_.join();
   }
 }
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -107,11 +107,10 @@ Worker::Worker(const std::string& node_ip_address, const std::string& scheduler_
 SubmitTaskReply Worker::submit_task(SubmitTaskRequest* request, int max_retries, int retry_wait_milliseconds) {
   RAY_CHECK(connected_, "Attempted to perform submit_task but failed.");
   SubmitTaskReply reply;
-  Status status;
   request->set_workerid(workerid_);
   for (int i = 0; i < 1 + max_retries; ++i) {
     ClientContext context;
-    status = scheduler_stub_->SubmitTask(&context, *request, &reply);
+    RAY_CHECK_GRPC(scheduler_stub_->SubmitTask(&context, *request, &reply));
     if (reply.function_registered()) {
       break;
     }
@@ -124,7 +123,7 @@ SubmitTaskReply Worker::submit_task(SubmitTaskRequest* request, int max_retries,
 bool Worker::kill_workers(ClientContext &context) {
   KillWorkersRequest request;
   KillWorkersReply reply;
-  Status status = scheduler_stub_->KillWorkers(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->KillWorkers(&context, request, &reply));
   return reply.success();
 }
 
@@ -173,7 +172,7 @@ void Worker::request_object(ObjectID objectid) {
   request.set_objectid(objectid);
   AckReply reply;
   ClientContext context;
-  Status status = scheduler_stub_->RequestObj(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->RequestObj(&context, request, &reply));
   return;
 }
 
@@ -184,7 +183,7 @@ ObjectID Worker::get_objectid() {
   request.set_workerid(workerid_);
   PutObjReply reply;
   ClientContext context;
-  Status status = scheduler_stub_->PutObj(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->PutObj(&context, request, &reply));
   return reply.objectid();
 }
 
@@ -240,7 +239,7 @@ void Worker::put_object(ObjectID objectid, const Obj* obj, std::vector<ObjectID>
   }
   AckReply reply;
   ClientContext context;
-  scheduler_stub_->AddContainedObjectIDs(&context, contained_objectids_request, &reply);
+   RAY_CHECK_GRPC(scheduler_stub_->AddContainedObjectIDs(&context, contained_objectids_request, &reply));
 }
 
 #define CHECK_ARROW_STATUS(s, msg)                              \
@@ -322,7 +321,7 @@ void Worker::alias_objectids(ObjectID alias_objectid, ObjectID target_objectid) 
   request.set_alias_objectid(alias_objectid);
   request.set_target_objectid(target_objectid);
   AckReply reply;
-  scheduler_stub_->AliasObjectIDs(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->AliasObjectIDs(&context, request, &reply));
 }
 
 void Worker::increment_reference_count(std::vector<ObjectID> &objectids) {
@@ -338,7 +337,7 @@ void Worker::increment_reference_count(std::vector<ObjectID> &objectids) {
       request.add_objectid(objectids[i]);
     }
     AckReply reply;
-    scheduler_stub_->IncrementRefCount(&context, request, &reply);
+    RAY_CHECK_GRPC(scheduler_stub_->IncrementRefCount(&context, request, &reply));
   }
 }
 
@@ -355,7 +354,7 @@ void Worker::decrement_reference_count(std::vector<ObjectID> &objectids) {
       request.add_objectid(objectids[i]);
     }
     AckReply reply;
-    scheduler_stub_->DecrementRefCount(&context, request, &reply);
+    RAY_CHECK_GRPC(scheduler_stub_->DecrementRefCount(&context, request, &reply));
   }
 }
 
@@ -367,7 +366,7 @@ void Worker::register_remote_function(const std::string& name, size_t num_return
   request.set_function_name(name);
   request.set_num_return_vals(num_return_vals);
   AckReply reply;
-  scheduler_stub_->RegisterRemoteFunction(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->RegisterRemoteFunction(&context, request, &reply));
 }
 
 void Worker::notify_failure(FailedType type, const std::string& name, const std::string& error_message) {
@@ -380,7 +379,7 @@ void Worker::notify_failure(FailedType type, const std::string& name, const std:
   request.mutable_failure()->set_name(name);
   request.mutable_failure()->set_error_message(error_message);
   AckReply reply;
-  scheduler_stub_->NotifyFailure(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->NotifyFailure(&context, request, &reply));
 }
 
 std::unique_ptr<WorkerMessage> Worker::receive_next_message() {
@@ -395,7 +394,7 @@ void Worker::ready_for_new_task() {
   ReadyForNewTaskRequest request;
   request.set_workerid(workerid_);
   AckReply reply;
-  scheduler_stub_->ReadyForNewTask(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->ReadyForNewTask(&context, request, &reply));
 }
 
 void Worker::disconnect() {
@@ -410,12 +409,12 @@ void Worker::disconnect() {
 // TODO(rkn): Should we be using pointers or references? And should they be const?
 void Worker::scheduler_info(ClientContext &context, SchedulerInfoRequest &request, SchedulerInfoReply &reply) {
   RAY_CHECK(connected_, "Attempted to get scheduler info but failed.");
-  scheduler_stub_->SchedulerInfo(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->SchedulerInfo(&context, request, &reply));
 }
 
 void Worker::task_info(ClientContext &context, TaskInfoRequest &request, TaskInfoReply &reply) {
   RAY_CHECK(connected_, "Attempted to get worker info but failed.");
-  scheduler_stub_->TaskInfo(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->TaskInfo(&context, request, &reply));
 }
 
 bool Worker::export_remote_function(const std::string& function_name, const std::string& function) {
@@ -425,7 +424,7 @@ bool Worker::export_remote_function(const std::string& function_name, const std:
   request.mutable_function()->set_name(function_name);
   request.mutable_function()->set_implementation(function);
   AckReply reply;
-  Status status = scheduler_stub_->ExportRemoteFunction(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->ExportRemoteFunction(&context, request, &reply));
   return true;
 }
 
@@ -437,7 +436,7 @@ void Worker::export_reusable_variable(const std::string& name, const std::string
   request.mutable_reusable_variable()->mutable_initializer()->set_implementation(initializer);
   request.mutable_reusable_variable()->mutable_reinitializer()->set_implementation(reinitializer);
   AckReply reply;
-  Status status = scheduler_stub_->ExportReusableVariable(&context, request, &reply);
+  RAY_CHECK_GRPC(scheduler_stub_->ExportReusableVariable(&context, request, &reply));
 }
 
 // Communication between the WorkerServer and the Worker happens via a message

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -100,7 +100,8 @@ Worker::Worker(const std::string& node_ip_address, const std::string& scheduler_
   // Start the worker service. This will find an unused port which is stored in
   // worker_port_. This also sets up a message queue between the worker and the
   // worker service.
-  start_worker_service(mode_);
+  if (mode_ == Mode::WORKER_MODE)
+    start_worker_service(mode_);
 }
 
 
@@ -399,11 +400,13 @@ void Worker::ready_for_new_task() {
 
 void Worker::disconnect() {
   connected_ = false;
-  // Shut down the worker service. This will cause the call to server->Wait() to
-  // return.
-  server_ptr_->Shutdown();
-  // Wait for the thread that launched the worker service to return.
-  worker_server_thread_.join();
+  if (mode_ == Mode::WORKER_MODE) {
+    // Shut down the worker service. This will cause the call to server->Wait() to
+    // return.
+    server_ptr_->Shutdown();
+    // Wait for the thread that launched the worker service to return.
+    worker_server_thread_.join();
+  }
 }
 
 // TODO(rkn): Should we be using pointers or references? And should they be const?


### PR DESCRIPTION
We recently introduced a GRPC service on drivers, which is used to report errors back that occurred on the workers. This seems to interfere with the way we perform testing (several drivers are created on one process) and seems to cause segfaults on MacOS X. The goal of this PR is to remove the GRPC service that is running on the drivers and instead have a separate thread that polls the scheduler for new errors and prints them to stdout.