### PR TITLE
Throw fatal error when attempting to send message on full queue.

### DIFF
--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -62,13 +62,16 @@ bool MessageQueue<>::connected() {
 }
 
 bool MessageQueue<>::send(const void * object, size_t size) {
+  bool succeeded;
   try {
-    queue_->send(object, size, 0);
+    // This will return true if the message was successfully sent and false if
+    // the message queue is full.
+    succeeded = queue_->try_send(object, size, 0);
   }
   catch (bip::interprocess_exception &ex) {
     RAY_CHECK(false, "boost::interprocess exception: " << ex.what());
   }
-  return true;
+  return succeeded;
 }
 
 bool MessageQueue<>::receive(void * object, size_t size) {


### PR DESCRIPTION
This switches from sending messages over boost interprocess message queues with `send` to using `try_send`, which returns false in a non-blocking manner when the message queue is full.

You can see the behavior by changing the default message queue size in `ipc.h` to something small like 10.