### PR TITLE
Automatically add relevant directories to Python paths of workers

### DIFF
--- a/doc/using-ray-on-a-cluster.md
+++ b/doc/using-ray-on-a-cluster.md
@@ -127,14 +127,9 @@ the tests.
     python test/array_test.py  # This tests some array libraries.
     ```
 
-6. Start the cluster with `cluster.start_ray()`. If you would like to deploy
-source code to it, you can pass in the local path to the directory that contains
-your Python code. For example, `cluster.start_ray("~/example_ray_code")`. This
-will copy your source code to each node on the cluster, placing it in a
-directory on the PYTHONPATH.
-The `cluster.start_ray` command will start the Ray scheduler, object stores, and
-workers, and before finishing it will print instructions for connecting to the
-cluster via ssh.
+6. Start the cluster with `cluster.start_ray()`. The `cluster.start_ray` command
+will start the Ray scheduler, object stores, and workers, and before finishing
+it will print instructions for connecting to the cluster via ssh.
 
 7. To connect to the cluster (either with a Python shell or with a script), ssh
 to the cluster's head node (as described by the output of the
@@ -146,7 +141,6 @@ to the cluster's head node (as described by the output of the
 
     Then run the following commands.
 
-        cd $HOME/ray
         source $HOME/ray/setup-env.sh  # Add Ray to your Python path.
 
     Then within a Python interpreter, run the following commands.
@@ -177,11 +171,14 @@ need to install a few more Python packages. This can be done, within
 
     - `cluster.install_ray()` - This pulls the Ray source code on each node,
       builds all of the third party libraries, and builds the project itself.
-    - `cluster.start_ray(user_source_directory=None, num_workers_per_node=10)` -
-      This starts a scheduler process on the head node, and it starts an object
-      store and some workers on each node.
+    - `cluster.start_ray(num_workers_per_node=10)` - This starts a scheduler
+      process on the head node, and it starts an object store and some workers
+      on each node.
     - `cluster.stop_ray()` - This shuts down the cluster (killing all of the
       processes).
+    - `cluster.copy_code_to_cluster(user_source_directory)` - This copies the
+      contents of `user_source_directory` locally to the cluster under
+      `~/ray_source_files/`.
     - `cluster.update_ray()` - This pulls the latest Ray source code and builds
       it.
     - `cluster.run_command_over_ssh_on_all_nodes_in_parallel(command)` - This

--- a/lib/python/ray/services.py
+++ b/lib/python/ray/services.py
@@ -82,7 +82,7 @@ def start_objstore(scheduler_address, node_ip_address, cleanup):
   if cleanup:
     all_processes.append(p)
 
-def start_worker(node_ip_address, worker_path, scheduler_address, objstore_address=None, cleanup=True, user_source_directory=None):
+def start_worker(node_ip_address, worker_path, scheduler_address, objstore_address=None, cleanup=True):
   """This method starts a worker process.
 
   Args:
@@ -96,18 +96,10 @@ def start_worker(node_ip_address, worker_path, scheduler_address, objstore_addre
     cleanup (Optional[bool]): True if using Ray in local mode. If cleanup is
       true, then this process will be killed by serices.cleanup() when the
       Python process that imported services exits. This is True by default.
-    user_source_directory (Optional[str]): The directory containing the
-      application code. This directory will be added to the path of each worker.
-      If not provided, the directory of the script currently being run is used.
   """
-  if user_source_directory is None:
-    # This extracts the directory of the script that is currently being run.
-    # This will allow users to import modules contained in this directory.
-    user_source_directory = os.path.dirname(os.path.abspath(os.path.join(os.path.curdir, sys.argv[0])))
   command = ["python",
              worker_path,
              "--node-ip-address=" + node_ip_address,
-             "--user-source-directory=" + user_source_directory,
              "--scheduler-address=" + scheduler_address]
   if objstore_address is not None:
     command.append("--objstore-address=" + objstore_address)
@@ -115,7 +107,7 @@ def start_worker(node_ip_address, worker_path, scheduler_address, objstore_addre
   if cleanup:
     all_processes.append(p)
 
-def start_node(scheduler_address, node_ip_address, num_workers, worker_path=None, user_source_directory=None, cleanup=False):
+def start_node(scheduler_address, node_ip_address, num_workers, worker_path=None, cleanup=False):
   """Start an object store and associated workers in the cluster setting.
 
   This starts an object store and the associated workers when Ray is being used
@@ -129,8 +121,6 @@ def start_node(scheduler_address, node_ip_address, num_workers, worker_path=None
     num_workers (int): The number of workers to be started on this node.
     worker_path (str): Path of the Python worker script that will be run on the
       worker.
-    user_source_directory (str): Path to the user's code the workers will import
-      modules from.
     cleanup (bool): If cleanup is True, then the processes started by this
       command will be killed when the process that imported services exits.
   """
@@ -139,7 +129,7 @@ def start_node(scheduler_address, node_ip_address, num_workers, worker_path=None
   if worker_path is None:
     worker_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../scripts/default_worker.py")
   for _ in range(num_workers):
-    start_worker(node_ip_address, worker_path, scheduler_address, user_source_directory=user_source_directory, cleanup=cleanup)
+    start_worker(node_ip_address, worker_path, scheduler_address, cleanup=cleanup)
   time.sleep(0.5)
 
 def start_workers(scheduler_address, objstore_address, num_workers, worker_path):

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -779,9 +779,13 @@ def connect(node_ip_address, scheduler_address, objstore_address=None, worker=gl
   _logger().propagate = False
   if mode in [raylib.SCRIPT_MODE, raylib.SILENT_MODE]:
     # Add the directory containing the script that is running to the Python
-    # paths of the workers.
+    # paths of the workers. Also add the current directory. Note that this
+    # assumes that the directory structures on the machines in the clusters are
+    # the same.
     script_directory = os.path.abspath(os.path.dirname(sys.argv[0]))
+    current_directory = os.path.abspath(os.path.curdir)
     worker.run_function_on_all_workers(lambda : sys.path.insert(1, script_directory))
+    worker.run_function_on_all_workers(lambda : sys.path.insert(1, current_directory))
     # Export cached remote functions to the workers.
     for function_name, function_to_export in worker.cached_remote_functions:
       raylib.export_remote_function(worker.handle, function_name, function_to_export)

--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import traceback
 import copy
@@ -516,6 +517,23 @@ class Worker(object):
     objectids = raylib.submit_task(self.handle, task_capsule)
     return objectids
 
+  def run_function_on_all_workers(self, function):
+    """Run arbitrary code on all of the workers.
+
+    This function will first be run on the driver, and then it will be exported
+    to all of the workers to be run. It will also be run on any new workers that
+    register later.
+
+    Args:
+      function (Callable): The function to run on all of the workers. It should
+        not take any arguments. If it returns anything, its return values will
+        not be used.
+    """
+    # First run the function on the driver.
+    function()
+    # Then run the function on all of the workers.
+    raylib.run_function_on_all_workers(self.handle, pickling.dumps(function))
+
 global_worker = Worker()
 """Worker: The global Worker object for this worker process.
 
@@ -760,8 +778,14 @@ def connect(node_ip_address, scheduler_address, objstore_address=None, worker=gl
   _logger().setLevel(logging.DEBUG)
   _logger().propagate = False
   if mode in [raylib.SCRIPT_MODE, raylib.SILENT_MODE]:
+    # Add the directory containing the script that is running to the Python
+    # paths of the workers.
+    script_directory = os.path.abspath(os.path.dirname(sys.argv[0]))
+    worker.run_function_on_all_workers(lambda : sys.path.insert(1, script_directory))
+    # Export cached remote functions to the workers.
     for function_name, function_to_export in worker.cached_remote_functions:
       raylib.export_remote_function(worker.handle, function_name, function_to_export)
+    # Export cached reusable variables to the workers.
     for name, reusable_variable in reusables._cached_reusables:
       _export_reusable_variable(name, reusable_variable)
   worker.cached_remote_functions = None
@@ -998,6 +1022,23 @@ def main_loop(worker=global_worker):
     else:
       _logger().info("Successfully imported reusable variable {}.".format(reusable_variable_name))
 
+  def process_function_to_run(serialized_function):
+    """Run on arbitrary function on the worker."""
+    try:
+      # Deserialize the function.
+      function = pickling.loads(serialized_function)
+      # Run the function.
+      function()
+    except:
+      # If an exception was thrown when the function was run, we record the
+      # traceback and notify the scheduler of the failure.
+      traceback_str = format_error_message(traceback.format_exc())
+      _logger().info("Failed to run function on worker. Failed with message: \n\n{}\n".format(traceback_str))
+      # Notify the scheduler that running the function failed.
+      # TODO(rkn): Notify the scheduler.
+    else:
+      _logger().info("Successfully ran function on worker.")
+
   while True:
     command, command_args = raylib.wait_for_next_message(worker.handle)
     try:
@@ -1013,6 +1054,9 @@ def main_loop(worker=global_worker):
       elif command == "reusable_variable":
         name, initializer_str, reinitializer_str = command_args
         process_reusable_variable(name, initializer_str, reinitializer_str)
+      elif command == "function_to_run":
+        serialized_function = command_args
+        process_function_to_run(serialized_function)
       else:
         _logger().info("Reached the end of the if-else loop in the main loop. This should be unreachable.")
         assert False, "This code should be unreachable."

--- a/protos/ray.proto
+++ b/protos/ray.proto
@@ -52,6 +52,8 @@ service Scheduler {
   rpc TaskInfo(TaskInfoRequest) returns (TaskInfoReply);
   // Kills the workers
   rpc KillWorkers(KillWorkersRequest) returns (KillWorkersReply);
+  // Run a function on all workers
+  rpc RunFunctionOnAllWorkers(RunFunctionOnAllWorkersRequest) returns (AckReply);
   // Exports function to the workers
   rpc ExportRemoteFunction(ExportRemoteFunctionRequest) returns (AckReply);
   // Ship an initializer and reinitializer for a reusable variable to the workers
@@ -247,6 +249,10 @@ message KillWorkersReply {
   bool success = 1;  // Currently, the only reason to fail is if there are workers still executing tasks
 }
 
+message RunFunctionOnAllWorkersRequest {
+  Function function = 1;
+}
+
 message ExportRemoteFunctionRequest {
   Function function = 1;
 }
@@ -274,6 +280,7 @@ message ObjStoreInfoReply {
 
 service WorkerService {
   rpc ExecuteTask(ExecuteTaskRequest) returns (AckReply); // Scheduler calls a function from the worker
+  rpc RunFunctionOnWorker(RunFunctionOnWorkerRequest) returns (AckReply); // Runs a function on the worker.
   rpc ImportRemoteFunction(ImportRemoteFunctionRequest) returns (AckReply); // Scheduler imports a function into the worker
   rpc ImportReusableVariable(ImportReusableVariableRequest) returns (AckReply); // Scheduler imports a reusable variable into the worker
   rpc Die(DieRequest) returns (AckReply); // Kills this worker
@@ -282,6 +289,10 @@ service WorkerService {
 
 message ExecuteTaskRequest {
   Task task = 1; // Contains name of the function to be executed and arguments
+}
+
+message RunFunctionOnWorkerRequest {
+  Function function = 1;
 }
 
 message ImportRemoteFunctionRequest {
@@ -302,6 +313,7 @@ message WorkerMessage {
     Task task = 1; // A task for the worker to execute.
     Function function = 2; // A remote function to import on the worker.
     ReusableVar reusable_variable = 3; // A reusable variable to import on the worker.
+    Function function_to_run = 4; // An arbitrary function to run on the worker.
   }
 }
 

--- a/scripts/default_worker.py
+++ b/scripts/default_worker.py
@@ -5,19 +5,12 @@ import numpy as np
 import ray
 
 parser = argparse.ArgumentParser(description="Parse addresses for the worker to connect to.")
-parser.add_argument("--user-source-directory", type=str, help="the directory containing the user's application code")
 parser.add_argument("--node-ip-address", required=True, type=str, help="the ip address of the worker's node")
 parser.add_argument("--scheduler-address", required=True, type=str, help="the scheduler's address")
 parser.add_argument("--objstore-address", type=str, help="the objstore's address")
 
 if __name__ == "__main__":
   args = parser.parse_args()
-  if args.user_source_directory is not None:
-    # Adding the directory containing the user's application code to the Python
-    # path so that the worker can import Python modules from this directory. We
-    # insert into the first position (as opposed to the zeroth) because the
-    # zeroth position is reserved for the empty string.
-    sys.path.insert(1, args.user_source_directory)
   ray.worker.connect(args.node_ip_address, args.scheduler_address)
 
   ray.worker.main_loop()

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -26,6 +26,7 @@ Status WorkerServiceImpl::ExecuteTask(ServerContext* context, const ExecuteTaskR
     WorkerMessage* message_ptr = message.get();
     RAY_CHECK(send_queue_.send(&message_ptr), "Failed to send message from the worker service to the worker because the message queue was full.");
   }
+  // The message will get deleted in receive_next_message().
   message.release();
   return Status::OK;
 }
@@ -39,6 +40,7 @@ Status WorkerServiceImpl::RunFunctionOnWorker(ServerContext* context, const RunF
     WorkerMessage* message_ptr = message.get();
     RAY_CHECK(send_queue_.send(&message_ptr), "Failed to send message from the worker service to the worker because the message queue was full.");
   }
+  // The message will get deleted in receive_next_message().
   message.release();
   return Status::OK;
 }
@@ -52,6 +54,7 @@ Status WorkerServiceImpl::ImportRemoteFunction(ServerContext* context, const Imp
     WorkerMessage* message_ptr = message.get();
     RAY_CHECK(send_queue_.send(&message_ptr), "Failed to send message from the worker service to the worker because the message queue was full.");
   }
+  // The message will get deleted in receive_next_message().
   message.release();
   return Status::OK;
 }
@@ -65,6 +68,7 @@ Status WorkerServiceImpl::ImportReusableVariable(ServerContext* context, const I
     WorkerMessage* message_ptr = message.get();
     RAY_CHECK(send_queue_.send(&message_ptr), "Failed to send message from the worker service to the worker because the message queue was full.");
   }
+  // The message will get deleted in receive_next_message().
   message.release();
   return Status::OK;
 }

--- a/src/worker.h
+++ b/src/worker.h
@@ -32,6 +32,7 @@ class WorkerServiceImpl final : public WorkerService::Service {
 public:
   WorkerServiceImpl(const std::string& worker_address, Mode mode);
   Status ExecuteTask(ServerContext* context, const ExecuteTaskRequest* request, AckReply* reply) override;
+  Status RunFunctionOnWorker(ServerContext* context, const RunFunctionOnWorkerRequest* request, AckReply* reply) override;
   Status ImportRemoteFunction(ServerContext* context, const ImportRemoteFunctionRequest* request, AckReply* reply) override;
   Status Die(ServerContext* context, const DieRequest* request, AckReply* reply) override;
   Status ImportReusableVariable(ServerContext* context, const ImportReusableVariableRequest* request, AckReply* reply) override;
@@ -104,6 +105,8 @@ class Worker {
   void task_info(ClientContext &context, TaskInfoRequest &request, TaskInfoReply &reply);
   // gets indices of available objects
   std::vector<int> select(std::vector<ObjectID>& objectids);
+  // Export a function to be run on all workers.
+  void run_function_on_all_workers(const std::string& function);
   // export function to workers
   bool export_remote_function(const std::string& function_name, const std::string& function);
   // export reusable variable to workers


### PR DESCRIPTION
This PR does several things.

- When `ray.init` is called, automatically add the current directory `os.path.abspath(os.path.curdir)` to the paths of all the workers, and automatically add the directory of the script that is running `os.path.abspath(sys.argv[0])` to the paths of all the workers. Note that this assumes that all of the machines in the cluster have a similar directory structure.
- Decouple starting the cluster from copying user source code to the cluster. Now there are two methods `cluster.start_ray()`, which no longer takes a user source directory, and `cluster.copy_code_to_cluster(user_source_directory)`.