### PR TITLE
Throw a fatal error if a gRPC message fails.

### DIFF
--- a/include/ray/logging.h
+++ b/include/ray/logging.h
@@ -61,8 +61,13 @@ extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 #define RAY_CHECK_GE(var1, var2, message) RAY_CHECK((var1) >= (var2), message)
 #define RAY_CHECK_GT(var1, var2, message) RAY_CHECK((var1) > (var2), message)
 
-#define RAY_CHECK_GRPC(expr) \
+#define RAY_WARN_GRPC(expr) \
   do { \
     grpc::Status _s = (expr); \
     RAY_WARN(_s.ok(), "grpc call failed with message " << _s.error_message()); \
+  } while (0);
+#define RAY_CHECK_GRPC(expr) \
+  do { \
+    grpc::Status _s = (expr); \
+    RAY_CHECK(_s.ok(), "grpc call failed with message " << _s.error_message()); \
   } while (0);

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -378,7 +378,7 @@ void Worker::decrement_reference_count(std::vector<ObjectID> &objectids) {
       request.add_objectid(objectids[i]);
     }
     AckReply reply;
-    RAY_CHECK_GRPC(scheduler_stub_->DecrementRefCount(&context, request, &reply));
+    RAY_WARN_GRPC(scheduler_stub_->DecrementRefCount(&context, request, &reply));
   }
 }
 


### PR DESCRIPTION
Except for decrementing a reference count, which can happen after Ray shuts down, so in this case we log a warning.

This improves the error message that is shown when you try

``` python
import ray
ray.init(node_ip_address="127.0.0.1", scheduler_address="127.0.0.1:23434")
```

before a scheduler has actually been started.

This addresses a problem mentioned by @rshin.
