### PR TITLE
Work around Arrow bug by increasing metadata size.

### DIFF
--- a/lib/python/ray/worker.py
+++ b/lib/python/ray/worker.py
@@ -348,7 +348,7 @@ class Worker(object):
     # in the following line, the "8" is for storing the metadata size,
     # the len(schema) is for storing the metadata and the 8192 is for storing
     # the metadata in the batch (see INITIAL_METADATA_SIZE in arrow)
-    size = size + 8 + len(schema) + 4096
+    size = size + 8 + len(schema) + 4096 * 4
     buff, segmentid = raylib.allocate_buffer(self.handle, objectid, size)
     # write the metadata length
     np.frombuffer(buff, dtype="int64", count=1)[0] = len(schema)
@@ -371,7 +371,7 @@ class Worker(object):
     """
     assert raylib.is_arrow(self.handle, objectid), "All objects should be serialized using Arrow."
     buff, segmentid, metadata_offset = raylib.get_buffer(self.handle, objectid)
-    metadata_size = np.frombuffer(buff, dtype="int64", count=1)[0]
+    metadata_size = int(np.frombuffer(buff, dtype="int64", count=1)[0])
     metadata = np.frombuffer(buff, dtype="byte", offset=8, count=metadata_size)
     data = np.frombuffer(buff, dtype="byte")[8 + metadata_size:]
     serialized = libnumbuf.read_from_buffer(memoryview(data), bytearray(metadata), metadata_offset)


### PR DESCRIPTION
When doing `ray.get` on an object, sometimes the following error occurs.

```
/Users/rkn/ray/thirdparty/numbuf/python/src/pynumbuf/numbuf.cc122Check failed: _s.ok() Bad status: Invalid: Metadata message is not a record batch
```

This is presumably a bug in Arrow. It's possible that this has been fixed in Arrow by now, but this is a temporary solution which doesn't solve the problem, but should reduce the number of situations in which it occurs.