### PR TITLE
Give better error message when no workers have been registered.

### DIFF
--- a/protos/ray.proto
+++ b/protos/ray.proto
@@ -105,7 +105,8 @@ message SubmitTaskRequest {
 
 message SubmitTaskReply {
   repeated uint64 result = 1; // Object IDs of the function return values
-  bool function_registered = 2; // True if the function was registered; false otherwise
+  bool function_registered = 2; // True if the function was registered, false otherwise
+  bool no_workers = 3; // True if no workers have registered with the scheduler, false otherwise
 }
 
 message RequestObjRequest {

--- a/src/worker.h
+++ b/src/worker.h
@@ -53,7 +53,7 @@ class Worker {
   // Submit a remote task to the scheduler. If the function in the task is not
   // registered with the scheduler, we will sleep for retry_wait_milliseconds
   // and try to resubmit the task to the scheduler up to max_retries more times.
-  SubmitTaskReply submit_task(SubmitTaskRequest* request, int max_retries = 120, int retry_wait_milliseconds = 500);
+  SubmitTaskReply submit_task(SubmitTaskRequest* request, int max_retries = 10, int retry_wait_milliseconds = 500);
   // Requests the scheduler to kill workers
   bool kill_workers(ClientContext &context);
   // send request to the scheduler to register this worker


### PR DESCRIPTION
This also reduces the timeout from one minute to 5 seconds when you submit a function that hasn't been registered.

Now, if you do

```python
import ray
ray.init(start_ray_local=True, num_workers=0)

@ray.remote
def f():
  return 1

f.remote()
```

It will throw the exception

```python
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-4-520f46ece26b> in <module>()
----> 1 f.remote(3)

/Users/rkn/Workspace/ray/lib/python/ray/worker.pyc in func_call(*args, **kwargs)
   1111           # the usual behavior of immutable remote objects.
   1112           return func(*copy.deepcopy(args))
-> 1113         objectids = _submit_task(func_name, args)
   1114         if len(objectids) == 1:
   1115           return objectids[0]

/Users/rkn/Workspace/ray/lib/python/ray/worker.pyc in _submit_task(func_name, args, worker)
   1056   which cannot be serialized.
   1057   """
-> 1058   return worker.submit_task(func_name, args)
   1059 
   1060 def _mode(worker=global_worker):

/Users/rkn/Workspace/ray/lib/python/ray/worker.pyc in submit_task(self, func_name, args)
    416     args = [arg if isinstance(arg, raylib.ObjectID) else put(arg, worker=self) for arg in args]
    417     task_capsule = raylib.serialize_task(self.handle, func_name, args)
--> 418     objectids = raylib.submit_task(self.handle, task_capsule)
    419     return objectids
    420 

error: No workers have registered with the scheduler, so this function cannot be run.
```