### PR TITLE
This solves a problem where exports were sent to workers out of order.

### DIFF
--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -385,7 +385,7 @@ Status SchedulerService::ReadyForNewTask(ServerContext* context, const ReadyForN
       // Check if the worker has been initialized yet, and if not, then give it
       // all of the exported functions and all of the exported reusable variables.
       if (!(*workers)[workerid].initial_exports_done) {
-        // This only needs to happen for this specific worker and not fo all
+        // This only needs to happen for this specific worker and not for all
         // workers.
         export_everything_to_all_workers_if_necessary(workers);
       }

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -38,7 +38,7 @@ struct WorkerHandle {
   ObjStoreId objstoreid;
   std::string worker_address;
   // This field is initialized to false, and it is set to true after all of the
-  // initial exports have been shipped to this worker, which happens the first.
+  // initial exports have been shipped to this worker.
   bool initial_exports_done;
   OperationId current_task;
 };

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -2,7 +2,6 @@
 #define RAY_SCHEDULER_H
 
 
-#include <queue>
 #include <deque>
 #include <memory>
 #include <algorithm>
@@ -120,12 +119,6 @@ private:
   ObjStoreId pick_objstore(ObjectID objectid);
   // checks if objectid is a canonical objectid
   bool is_canonical(ObjectID objectid);
-  // Export all queued up functions to run.
-  void perform_functions_to_run();
-  // Export all queued up remote functions.
-  void perform_remote_function_exports();
-  // Export all queued up reusable variables.
-  void perform_reusable_variable_exports();
   // Perform all queued up gets that can be performed.
   void perform_gets();
   // schedule tasks using the naive algorithm
@@ -155,18 +148,24 @@ private:
   // Export a function to run to a worker.
   void export_function_to_run_to_worker(WorkerId workerid, int function_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_functions_to_run);
   // Export a remote function to a worker.
-  void export_function_to_worker(WorkerId workerid, int function_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_functions);
+  void export_remote_function_to_worker(WorkerId workerid, int function_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_remote_functions);
   // Export a reusable variable to a worker
   void export_reusable_variable_to_worker(WorkerId workerid, int reusable_variable_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<ReusableVar> > > &exported_reusable_variables);
-  // Add to the function to run export queue the job of exporting all functions
-  // to run to the given worker. This is used when a new worker registers.
-  void add_all_functions_to_run_to_worker_queue(WorkerId workerid);
-  // Add to the remote function export queue the job of exporting all remote
-  // functions to the given worker. This is used when a new worker registers.
-  void add_all_remote_functions_to_worker_export_queue(WorkerId workerid);
-  // Add to the reusable variable export queue the job of exporting all reusable
-  // variables to the given worker. This is used when a new worker registers.
-  void add_all_reusable_variables_to_worker_export_queue(WorkerId workerid);
+  // Export all functions to run to a worker. This is used when a new worker
+  // registers and is protected by the workers lock (which is passed in) to
+  // ensure that no other exports are exported to the worker while this method
+  // is being called.
+  void export_all_functions_to_run_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_functions_to_run);
+  // Export all reusable variables to a worker. This is used when a new worker
+  // registers and is protected by the workers lock (which is passed in) to
+  // ensure that no other exports are exported to the worker while this method
+  // is being called.
+  void export_all_remote_functions_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_remote_functions);
+  // Export all remote functions to a worker. This is used when a new worker
+  // registers and is protected by the workers lock (which is passed in) to
+  // ensure that no other exports are exported to the worker while this method
+  // is being called.
+  void export_all_reusable_variables_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<ReusableVar> > > &exported_reusable_variables);
 
   template<class T>
   MySynchronizedPtr<T> get(Synchronized<T>& my_field, const char* name,unsigned int line_number);
@@ -237,25 +236,10 @@ private:
   // lock (objects_lock_). // TODO(rkn): Consider making this part of the
   // objtable data structure.
   std::vector<std::vector<ObjectID> > objects_in_transit_;
-  // List of pending functions to run on workers. These should be processed in a
-  // first in first out manner. The first element of each pair is the ID of the
-  // worker to run the function on, and the second element of each pair is the
-  // index of the function to run.
-  Synchronized<std::queue<std::pair<WorkerId, int> > > function_to_run_queue_;
-  // List of pending remote function exports. These should be processed in a
-  // first in first out manner. The first element of each pair is the ID of the
-  // worker to export the remote function to, and the second element of each
-  // pair is the index of the function to export.
-  Synchronized<std::queue<std::pair<WorkerId, int> > > remote_function_export_queue_;
-  // List of pending reusable variable exports. These should be processed in a
-  // first in first out manner. The first element of each pair is the ID of the
-  // worker to export the reusable variable to, and the second element of each
-  // pair is the index of the reusable variable to export.
-  Synchronized<std::queue<std::pair<WorkerId, int> > > reusable_variable_export_queue_;
   // All of the functions that have been exported to the workers to run.
   Synchronized<std::vector<std::unique_ptr<Function> > > exported_functions_to_run_;
   // All of the remote functions that have been exported to the workers.
-  Synchronized<std::vector<std::unique_ptr<Function> > > exported_functions_;
+  Synchronized<std::vector<std::unique_ptr<Function> > > exported_remote_functions_;
   // All of the reusable variables that have been exported to the workers.
   Synchronized<std::vector<std::unique_ptr<ReusableVar> > > exported_reusable_variables_;
   // the scheduling algorithm that will be used

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -38,9 +38,8 @@ struct WorkerHandle {
   ObjStoreId objstoreid;
   std::string worker_address;
   // This field is initialized to false, and it is set to true after all of the
-  // exported functions and exported reusable variables have been shipped to
-  // this worker.
-  bool initialized;
+  // initial exports have been shipped to this worker, which happens the first.
+  bool initial_exports_done;
   OperationId current_task;
 };
 
@@ -151,21 +150,10 @@ private:
   void export_remote_function_to_worker(WorkerId workerid, int function_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_remote_functions);
   // Export a reusable variable to a worker
   void export_reusable_variable_to_worker(WorkerId workerid, int reusable_variable_index, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<ReusableVar> > > &exported_reusable_variables);
-  // Export all functions to run to a worker. This is used when a new worker
-  // registers and is protected by the workers lock (which is passed in) to
-  // ensure that no other exports are exported to the worker while this method
-  // is being called.
-  void export_all_functions_to_run_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_functions_to_run);
-  // Export all reusable variables to a worker. This is used when a new worker
-  // registers and is protected by the workers lock (which is passed in) to
-  // ensure that no other exports are exported to the worker while this method
-  // is being called.
-  void export_all_remote_functions_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<Function> > > &exported_remote_functions);
-  // Export all remote functions to a worker. This is used when a new worker
-  // registers and is protected by the workers lock (which is passed in) to
-  // ensure that no other exports are exported to the worker while this method
-  // is being called.
-  void export_all_reusable_variables_to_worker(WorkerId workerid, MySynchronizedPtr<std::vector<WorkerHandle> > &workers, const MySynchronizedPtr<std::vector<std::unique_ptr<ReusableVar> > > &exported_reusable_variables);
+  // Export all exports to all workers that need them. This happens the first
+  // time any export would be exported to a worker or when a worker first calls
+  // ReadyForNewTask.
+  void export_everything_to_all_workers_if_necessary(MySynchronizedPtr<std::vector<WorkerHandle> > &workers);
 
   template<class T>
   MySynchronizedPtr<T> get(Synchronized<T>& my_field, const char* name,unsigned int line_number);


### PR DESCRIPTION
This is a partial solution to #411.

Ideally, we'd like every remote function, reusable variable, and function to run to have a counter 0, 1, 2, ..., and then we'd like each worker to import exports in the order of their counters.

The most important reason for this is that we have to run some functions to run before we import remote functions (because the functions to run set the path). That is done in this PR, however we don't implement the counter here, so there is still some stuff happening out of order.